### PR TITLE
remove duplicate groups in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.0.3
+
+* [DX]: Context now removes duplicates in groups.
+* [DX]: Better exception message for unknown constructor argument.
+
 # 2.0.2
 
 * [Bugfix]: Respect group configuration when no version is specified.

--- a/src/Context.php
+++ b/src/Context.php
@@ -36,7 +36,7 @@ final class Context
      */
     public function setGroups(array $groups): self
     {
-        $this->groups = $groups;
+        $this->groups = array_unique($groups);
 
         return $this;
     }

--- a/tests/Unit/ContextTest.php
+++ b/tests/Unit/ContextTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Unit\Path;
+
+use Liip\Serializer\Context;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @small
+ */
+class ContextTest extends TestCase
+{
+    public function testDuplicateGroups(): void
+    {
+        $context = new Context();
+        $context->setGroups(['a', 'b', 'a']);
+        static::assertSame(['a', 'b'], $context->getGroups());
+    }
+}


### PR DESCRIPTION
found some logs like `"Type "Model\Stuff" is not known in version 5 and groups api, api, details. Did you forgot to configure the generators to support this file or this combination of version and groups?`

while it is sloppy, there is no reason why this should not work.