### PR TITLE
Add support for (de-)serializing doctrine collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for generating recursive code up to a specified maximum depth
   that can be defined via the `@MaxDepth` annotation/attribute from JMS
+* Add support for (de-)serializing doctrine collections
 
 # 2.0.6
 

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,12 @@
         "twig/twig": "^2.7 || ^3.0"
     },
     "require-dev": {
+        "doctrine/collections": "^1.6",
+        "friendsofphp/php-cs-fixer": "^2.14",
+        "jms/serializer": "^1.13 || ^2 || ^3",
         "phpstan/phpstan": "^0.12.0",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^8.0",
-        "friendsofphp/php-cs-fixer": "^2.14",
-        "jms/serializer": "^1.13 || ^2 || ^3"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Configuration/ClassToGenerate.php
+++ b/src/Configuration/ClassToGenerate.php
@@ -62,6 +62,7 @@ class ClassToGenerate implements \IteratorAggregate
         $this->groupCombinations[] = $groupCombination;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         if ($this->groupCombinations) {

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -107,6 +107,7 @@ class GeneratorConfiguration implements \IteratorAggregate
         }, $this->defaultGroupCombinations);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->classesToGenerate);

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -186,6 +186,7 @@ final class SerializerGenerator
     ): string {
         if ($type instanceof PropertyTypeArray) {
             if ($type->getSubType() instanceof PropertyTypePrimitive) {
+                $modelPropertyPath = $type->isCollection() ? $modelPropertyPath . '->toArray()' : $modelPropertyPath;
                 // for arrays of scalars, copy the field even when its an empty array
                 return $this->templating->renderAssign($fieldPath, $modelPropertyPath);
             }
@@ -253,9 +254,9 @@ final class SerializerGenerator
         }
 
         if ($type->isHashmap()) {
-            return $this->templating->renderLoopHashmap($arrayPath, $modelPath, $index, $innerCode);
+            return $this->templating->renderLoopHashmap($arrayPath, $modelPath, $index, $innerCode, $type->isCollection());
         }
 
-        return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode);
+        return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode, $type->isCollection());
     }
 }

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -186,9 +186,8 @@ final class SerializerGenerator
     ): string {
         if ($type instanceof PropertyTypeArray) {
             if ($type->getSubType() instanceof PropertyTypePrimitive) {
-                $modelPropertyPath = $type->isCollection() ? $modelPropertyPath . '->toArray()' : $modelPropertyPath;
                 // for arrays of scalars, copy the field even when its an empty array
-                return $this->templating->renderAssign($fieldPath, $modelPropertyPath);
+                return $this->templating->renderArrayAssign($fieldPath, $modelPropertyPath);
             }
 
             // either array or hashmap with second param the type of values
@@ -254,9 +253,9 @@ final class SerializerGenerator
         }
 
         if ($type->isHashmap()) {
-            return $this->templating->renderLoopHashmap($arrayPath, $modelPath, $index, $innerCode, $type->isCollection());
+            return $this->templating->renderLoopHashmap($arrayPath, $modelPath, $index, $innerCode);
         }
 
-        return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode, $type->isCollection());
+        return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode);
     }
 }

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -93,6 +93,11 @@ foreach (array_keys({{jsonPath}}) as {{indexVariable}}) {
 
 EOT;
 
+    private const TMPL_ARRAY_COLLECTION = <<<'EOT'
+{{modelPath}} = new \Doctrine\Common\Collections\ArrayCollection({{tmpVariable}});
+
+EOT;
+
     private const TMPL_UNSET = <<<'EOT'
 unset({{variableNames|join(', ')}});
 
@@ -234,6 +239,14 @@ EOT;
             'jsonPath' => $jsonPath,
             'indexVariable' => $indexVariable,
             'code' => $code,
+        ]);
+    }
+
+    public function renderArrayCollection(string $modelPath, string $tmpVariable): string
+    {
+        return $this->render(self::TMPL_ARRAY_COLLECTION, [
+            'modelPath' => $modelPath,
+            'tmpVariable' => $tmpVariable,
         ]);
     }
 

--- a/src/Template/Serialization.php
+++ b/src/Template/Serialization.php
@@ -121,8 +121,10 @@ EOT;
         ]);
     }
 
-    public function renderLoopArray(string $jsonPath, string $propertyAccessor, string $indexVariable, string $code): string
+    public function renderLoopArray(string $jsonPath, string $propertyAccessor, string $indexVariable, string $code, bool $isCollection): string
     {
+        $propertyAccessor = $isCollection ? $propertyAccessor . '->toArray()' : $propertyAccessor;
+
         return $this->render(self::TMPL_LOOP_ARRAY, [
             'jsonPath' => $jsonPath,
             'propertyAccessor' => $propertyAccessor,
@@ -138,8 +140,10 @@ EOT;
         ]);
     }
 
-    public function renderLoopHashmap(string $jsonPath, string $propertyAccessor, string $indexVariable, string $code): string
+    public function renderLoopHashmap(string $jsonPath, string $propertyAccessor, string $indexVariable, string $code, bool $isCollection): string
     {
+        $propertyAccessor = $isCollection ? $propertyAccessor . '->toArray()' : $propertyAccessor;
+
         return $this->render(self::TMPL_LOOP_HASHMAP, [
             'jsonPath' => $jsonPath,
             'propertyAccessor' => $propertyAccessor,

--- a/tests/Fixtures/ListModel.php
+++ b/tests/Fixtures/ListModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Liip\Serializer\Fixtures;
 
+use Doctrine\Common\Collections\Collection;
 use JMS\Serializer\Annotation as Serializer;
 
 class ListModel
@@ -32,6 +33,20 @@ class ListModel
      * @Serializer\Accessor("getOptionalList")
      */
     public $optionalList;
+
+    /**
+     * @var string[]|Collection|null
+     *
+     * @Serializer\Type("ArrayCollection<string>")
+     */
+    public $collection;
+
+    /**
+     * @var Nested[string]|Collection|null
+     *
+     * @Serializer\Type("ArrayCollection<string, Tests\Liip\Serializer\Fixtures\Nested>")
+     */
+    public $collectionNested;
 
     public function getOptionalList()
     {

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Liip\Serializer\Unit;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Collections\ArrayCollection;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
@@ -83,6 +84,11 @@ class DeserializerGeneratorTest extends SerializerTestCase
                 ['nested_string' => 'nested1'],
                 ['nested_string' => 'nested2'],
             ],
+            'collection' => ['entry', 'second entry'],
+            'collection_nested' => [
+                'first' => ['nested_string' => 'nested3'],
+                'second' => ['nested_string' => 'nested4'],
+            ],
         ];
 
         /** @var ListModel $model */
@@ -91,10 +97,24 @@ class DeserializerGeneratorTest extends SerializerTestCase
         static::assertSame(['a', 'b'], $model->array);
         static::assertIsArray($model->listNested);
         static::assertCount(2, $model->listNested);
+
         foreach ($model->listNested as $index => $nested) {
             static::assertInstanceOf(Nested::class, $nested);
             static::assertSame('nested'.($index + 1), $nested->nestedString);
         }
+
+        static::assertInstanceOf(ArrayCollection::class, $model->collection);
+        static::assertCount(2, $model->collection);
+        static::assertSame(['entry', 'second entry'], $model->collection->toArray());
+
+        static::assertInstanceOf(ArrayCollection::class, $model->collectionNested);
+        static::assertCount(2, $model->collectionNested);
+        static::assertArrayHasKey('first', $model->collectionNested);
+        static::assertSame('nested3', $model->collectionNested['first']->nestedString);
+
+        static::assertArrayHasKey('second', $model->collectionNested);
+        static::assertSame('nested4', $model->collectionNested['second']->nestedString);
+
     }
 
     public function testRecursion(): void

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Liip\Serializer\Unit;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Collections\ArrayCollection;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
@@ -102,6 +103,8 @@ class SerializerGeneratorTest extends SerializerTestCase
             new Nested('opt1'),
             new Nested('opt2'),
         ];
+        $list->collection = new ArrayCollection(['a', 'b']);
+        $list->collectionNested = new ArrayCollection(['a' => new Nested('nested1'), 'b' => new Nested('nested2')]);
 
         $expected = [
             'array' => ['a', 'b'],
@@ -112,6 +115,11 @@ class SerializerGeneratorTest extends SerializerTestCase
             'optional_list' => [
                 ['nested_string' => 'opt1'],
                 ['nested_string' => 'opt2'],
+            ],
+            'collection' => ['a', 'b'],
+            'collection_nested' => [
+                'a' => ['nested_string' => 'nested1'],
+                'b' => ['nested_string' => 'nested2'],
             ],
         ];
 


### PR DESCRIPTION
This adds actual support for (de-)serializing doctrine collections, as the metadata-parser now provides this information (added via https://github.com/liip/metadata-parser/pull/29)

Side note: I also added the `ReturnTypeWillChange` attribute to the `getIterator` methods to get rid of some deprecation notices when using PHP 8.x