### PR TITLE
Generate recursive code up to the defined max depth value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.1.0 (unreleased)
+
+* Add support for generating recursive code up to a specified maximum depth
+  that can be defined via the `@MaxDepth` annotation/attribute from JMS
+
 # 2.0.6
 
 * Allow installation with liip/metadata-parser 0.5

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "doctrine/annotations": "^1.10.2",
-        "liip/metadata-parser": "^0.2 || ^0.3 || ^0.4 || ^0.5",
+        "liip/metadata-parser": "^0.6",
         "pnz/json-exception": "^1.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -171,6 +171,10 @@ final class DeserializerGenerator
         if ($propertyMetadata->isReadOnly()) {
             return '';
         }
+        
+        if (Recursion::hasMaxDepthReached($propertyMetadata, $stack)) {
+            return '';
+        }
 
         if ($propertyMetadata->getAccessor()->hasSetterMethod()) {
             $tempVariable = ModelPath::tempVariable([(string) $modelPath, $propertyMetadata->getName()]);

--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -22,12 +22,12 @@ abstract class Recursion
 
     public static function hasMaxDepthReached(PropertyMetadata $propertyMetadata, array $stack): bool
     {
-        $className = self::getClassNameFromProperty($propertyMetadata);
-        if (null === $className) {
+        if (null === $propertyMetadata->getMaxDepth()) {
             return false;
         }
 
-        if (null === $propertyMetadata->getMaxDepth()) {
+        $className = self::getClassNameFromProperty($propertyMetadata);
+        if (null === $className) {
             return false;
         }
 

--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Liip\Serializer;
 
+use Liip\MetadataParser\Metadata\PropertyMetadata;
+use Liip\MetadataParser\Metadata\PropertyTypeArray;
+use Liip\MetadataParser\Metadata\PropertyTypeClass;
+
 abstract class Recursion
 {
     public static function check(string $className, array $stack, string $modelPath): bool
@@ -13,5 +17,36 @@ abstract class Recursion
         }
 
         return false;
+    }
+
+
+    public static function hasMaxDepthReached(PropertyMetadata $propertyMetadata, array $stack): bool
+    {
+        $className = self::getClassNameFromProperty($propertyMetadata);
+        if (null === $className) {
+            return false;
+        }
+
+        if (null === $propertyMetadata->getMaxDepth()) {
+            return false;
+        }
+
+        $classStackCount = $stack[$className] ?? 0;
+
+        return $classStackCount > $propertyMetadata->getMaxDepth();
+    }
+
+    private static function getClassNameFromProperty(PropertyMetadata $propertyMetadata): ?string
+    {
+        $type = $propertyMetadata->getType();
+        if ($type instanceof PropertyTypeArray) {
+            $type = $type->getLeafType();
+        }
+
+        if (!($type instanceof PropertyTypeClass)) {
+            return null;
+        }
+
+        return $type->getClassName();
     }
 }

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -151,6 +151,10 @@ final class SerializerGenerator
         string $modelPath,
         array $stack
     ): string {
+        if (Recursion::hasMaxDepthReached($propertyMetadata, $stack)) {
+            return '';
+        }
+
         $modelPropertyPath = $modelPath.'->'.$propertyMetadata->getName();
         $fieldPath = $arrayPath.'["'.$propertyMetadata->getSerializedName().'"]';
 

--- a/tests/Fixtures/RecursionModel.php
+++ b/tests/Fixtures/RecursionModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class RecursionModel
+{
+    /**
+     * @Serializer\Type("string")
+     */
+    public $property;
+
+    /**
+     * @Serializer\MaxDepth(2)
+     * @Serializer\Type("Tests\Liip\Serializer\Fixtures\RecursionModel")
+     */
+    public $recursion;
+}

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -19,6 +19,7 @@ use Tests\Liip\Serializer\Fixtures\Model;
 use Tests\Liip\Serializer\Fixtures\Nested;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
+use Tests\Liip\Serializer\Fixtures\RecursionModel;
 use Tests\Liip\Serializer\Fixtures\Versions;
 use Tests\Liip\Serializer\Fixtures\VirtualProperties;
 
@@ -115,6 +116,34 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
 
         $data = $functionName($list);
+        static::assertSame($expected, $data);
+    }
+
+    public function testRecursions(): void
+    {
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_RecursionModel';
+        self::generateSerializers(self::$metadataBuilder, RecursionModel::class, [$functionName], ['']);
+
+        $model = new RecursionModel();
+        $model->property = 'property';
+        $model->recursion = new RecursionModel();
+        $model->recursion->property = 'recursive property';
+        $model->recursion->recursion = new RecursionModel();
+        $model->recursion->recursion->property = 'recursive recursive property';
+        $model->recursion->recursion->recursion = new RecursionModel();
+        $model->recursion->recursion->recursion->property = 'recursive recursive recursive property';
+
+        $expected = [
+            'property'=> 'property',
+            'recursion' => [
+                'property' => 'recursive property',
+                'recursion' => [
+                    'property' => 'recursive recursive property',
+                ],
+            ],
+        ];
+
+        $data = $functionName($model);
         static::assertSame($expected, $data);
     }
 


### PR DESCRIPTION
With this addition, it is now possible to generate recursive code up to a specified maximum depth that can be provided via the `MaxDepth` annotation/attribute from JMS