### PR TITLE
Assign array directly if type is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 # 2.2.0 (unreleased)
 
 * Add new parameter `$options` to the `GenerateConfiguration` class
-* Support (de)serializing unknown arrays by setting the `allow_generic_arrays`
-  option to `true`.
+* Support (de)serializing arrays with undefined content by setting the
+  `allow_generic_arrays` option to `true`.
 
 # 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 2.2.0 (unreleased)
+
+* Add new parameter `$options` to the `GenerateConfiguration` class
+* Support (de)serializing unknown arrays by setting the `assign_unknown_arrays`
+  option to `true`.
+
 # 2.1.0
 
 * Add support for generating recursive code up to a specified maximum depth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 2.2.0 (unreleased)
 
 * Add new parameter `$options` to the `GenerateConfiguration` class
-* Support (de)serializing unknown arrays by setting the `assign_unknown_arrays`
+* Support (de)serializing unknown arrays by setting the `allow_generic_arrays`
   option to `true`.
 
 # 2.1.0

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ use Liip\Serializer\Template\Deserialization;
 use Liip\Serializer\Template\Serialization;
 
 $configuration = GeneratorConfiguration::createFomArray([
+    'options' => [
+        'assign_unknown_arrays' => false,
+    ],
     'default_group_combinations' => ['api'],
     'default_versions' => ['', '1', '2'],
     'classes' => [
@@ -102,6 +105,11 @@ To generate a file without version, specify version `''` in the list of versions
 #### Groups
 
 To generate a serializer without groups, specify an empty group combination `[]`.
+
+### Arrays with an unknown type
+
+If you want to directly assign arrays with an unknown type, you can do that by 
+setting the `assign_unknown_arrays` value to `true` via the `options` argument.
 
 ## Serialize using the generated code
 In this example, we serialize an object of class `Product` for version 2:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use Liip\Serializer\Template\Serialization;
 
 $configuration = GeneratorConfiguration::createFomArray([
     'options' => [
-        'assign_unknown_arrays' => false,
+        'allow_generic_arrays' => false,
     ],
     'default_group_combinations' => ['api'],
     'default_versions' => ['', '1', '2'],
@@ -109,7 +109,7 @@ To generate a serializer without groups, specify an empty group combination `[]`
 ### Arrays with an unknown type
 
 If you want to directly assign arrays with an unknown type, you can do that by 
-setting the `assign_unknown_arrays` value to `true` via the `options` argument.
+setting the `allow_generic_arrays` value to `true` via the `options` argument.
 
 ## Serialize using the generated code
 In this example, we serialize an object of class `Product` for version 2:

--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ To generate a serializer without groups, specify an empty group combination `[]`
 
 ### Arrays with an unknown type
 
-If you want to directly assign arrays with an unknown type, you can do that by 
+If you want to (de)serialize arrays with undefined content, you can do that by
 setting the `allow_generic_arrays` value to `true` via the `options` argument.
+
+Note: This will only work if the contents of that array are only primitive
+types (string, int, float, boolean and nested arrays with only these types).
 
 ## Serialize using the generated code
 In this example, we serialize an object of class `Product` for version 2:

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "pnz/json-exception": "^1.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
+        "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0",
         "twig/twig": "^2.7 || ^3.0"
     },
     "require-dev": {

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -36,16 +36,23 @@ class GeneratorConfiguration implements \IteratorAggregate
      */
     private $classesToGenerate = [];
 
-    public function __construct(array $defaultGroupCombinations, array $defaultVersions)
+    /**
+     * @var bool
+     */
+    private $assignUnknownArrays;
+
+    public function __construct(array $defaultGroupCombinations, array $defaultVersions, bool $assignUnknownArrays = false)
     {
         $this->defaultGroupCombinations = $defaultGroupCombinations ?: [[]];
         $this->defaultVersions = array_map('strval', $defaultVersions) ?: [''];
+        $this->assignUnknownArrays = $assignUnknownArrays;
     }
 
     /**
      * Create configuration from array definition
      *
      * [
+     *     'assign_unknown_arrays' => true,
      *     'default_group_combinations' => ['api'],
      *     'default_versions' => ['', '1', '2'],
      *     'classes' => [
@@ -73,7 +80,9 @@ class GeneratorConfiguration implements \IteratorAggregate
         if (!\array_key_exists('classes', $config) || \count($config['classes']) < 1) {
             throw new \InvalidArgumentException('You need to specify the classes to generate');
         }
-        $instance = new self($config['default_group_combinations'] ?? [], $config['default_versions'] ?? []);
+
+        $assignUnknownArrays = $config['assign_unknown_arrays'] ?? false;
+        $instance = new self($config['default_group_combinations'] ?? [], $config['default_versions'] ?? [], $assignUnknownArrays);
         foreach ($config['classes'] as $className => $classConfig) {
             $classToGenerate = new ClassToGenerate($instance, $className, $classConfig['default_versions'] ?? null);
             foreach ($classConfig['group_combinations'] ?? [] as $groupCombination) {
@@ -105,6 +114,11 @@ class GeneratorConfiguration implements \IteratorAggregate
         return array_map(static function (array $combination) use ($classToGenerate) {
             return new GroupCombination($classToGenerate, $combination);
         }, $this->defaultGroupCombinations);
+    }
+
+    public function shouldAssignUnknownArrays(): bool
+    {
+        return $this->assignUnknownArrays;
     }
 
     #[\ReturnTypeWillChange]

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -120,6 +120,10 @@ class GeneratorConfiguration implements \IteratorAggregate
         }, $this->defaultGroupCombinations);
     }
 
+    /**
+     * If this is false, arrays with sub type PropertyTypeUnknown are treated as error.
+     * If this is true, deserialize assigns the raw array and serialize just takes the raw content of the field.
+     */
     public function shouldAllowGenericArrays(): bool
     {
         return $this->options['allow_generic_arrays'];

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -55,7 +55,7 @@ class GeneratorConfiguration implements \IteratorAggregate
      *
      * [
      *     'options' => [
-     *         'assign_unknown_arrays' => true,
+     *         'allow_generic_arrays' => true,
      *     ],
      *     'default_group_combinations' => ['api'],
      *     'default_versions' => ['', '1', '2'],
@@ -120,9 +120,9 @@ class GeneratorConfiguration implements \IteratorAggregate
         }, $this->defaultGroupCombinations);
     }
 
-    public function shouldAssignUnknownArrays(): bool
+    public function shouldAllowGenericArrays(): bool
     {
-        return $this->options['assign_unknown_arrays'];
+        return $this->options['allow_generic_arrays'];
     }
 
     #[\ReturnTypeWillChange]
@@ -135,10 +135,10 @@ class GeneratorConfiguration implements \IteratorAggregate
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'assign_unknown_arrays' => false
+            'allow_generic_arrays' => false
         ]);
 
-        $resolver->setAllowedTypes('assign_unknown_arrays', 'boolean');
+        $resolver->setAllowedTypes('allow_generic_arrays', 'boolean');
 
         return $resolver->resolve($options);
     }

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -85,8 +85,7 @@ class GeneratorConfiguration implements \IteratorAggregate
             throw new \InvalidArgumentException('You need to specify the classes to generate');
         }
 
-        $options = $config['options'] ?? [];
-        $instance = new self($config['default_group_combinations'] ?? [], $config['default_versions'] ?? [], $options);
+        $instance = new self($config['default_group_combinations'] ?? [], $config['default_versions'] ?? [], $config['options'] ?? []);
         foreach ($config['classes'] as $className => $classConfig) {
             $classToGenerate = new ClassToGenerate($instance, $className, $classConfig['default_versions'] ?? null);
             foreach ($classConfig['group_combinations'] ?? [] as $groupCombination) {

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -282,6 +282,9 @@ final class DeserializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $arrayPropertyPath, $modelPropertyPath, $stack);
                 break;
 
+            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAssignUnknownArrays():
+                return $this->templating->renderAssignJsonDataToField((string) $modelPath, (string) $arrayPath);
+
             default:
                 throw new \Exception('Unexpected array subtype '.\get_class($subType));
         }

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -282,7 +282,7 @@ final class DeserializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $arrayPropertyPath, $modelPropertyPath, $stack);
                 break;
 
-            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAssignUnknownArrays():
+            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
                 return $this->templating->renderAssignJsonDataToField((string) $modelPath, (string) $arrayPath);
 
             default:

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -13,6 +13,8 @@ use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\Reducer\TakeBestReducer;
+use Liip\Serializer\Configuration\ClassToGenerate;
+use Liip\Serializer\Configuration\GeneratorConfiguration;
 use Liip\Serializer\Path\ArrayPath;
 use Liip\Serializer\Path\ModelPath;
 use Liip\Serializer\Template\Deserialization;
@@ -51,17 +53,24 @@ final class DeserializerGenerator
     private $cacheDirectory;
 
     /**
+     * @var GeneratorConfiguration
+     */
+    private $configuration;
+
+    /**
      * @param string[] $classesToGenerate
      */
     public function __construct(
         Deserialization $templating,
         array $classesToGenerate,
-        string $cacheDirectory
+        string $cacheDirectory,
+        GeneratorConfiguration $configuration = null
     ) {
+
         $this->templating = $templating;
-        $this->classesToGenerate = $classesToGenerate;
         $this->cacheDirectory = $cacheDirectory;
         $this->filesystem = new Filesystem();
+        $this->configuration = $this->createGeneratorConfiguration($configuration, $classesToGenerate);
     }
 
     public static function buildDeserializerFunctionName(string $className): string
@@ -73,10 +82,11 @@ final class DeserializerGenerator
     {
         $this->filesystem->mkdir($this->cacheDirectory);
 
-        foreach ($this->classesToGenerate as $className) {
+        /** @var ClassToGenerate $classToGenerate */
+        foreach ($this->configuration as $classToGenerate) {
             // we do not use the oldest version reducer here and hope for the best
             // otherwise we end up with generated property names for accessor methods
-            $classMetadata = $metadataBuilder->build($className, [
+            $classMetadata = $metadataBuilder->build($classToGenerate->getClassName(), [
                 new TakeBestReducer(),
             ]);
             $this->writeFile($classMetadata);
@@ -303,5 +313,18 @@ final class DeserializerGenerator
         $code = $innerCode . $this->templating->renderArrayCollection((string) $modelPath, (string) $tmpVariable);
 
         return $code;
+    }
+
+    private function createGeneratorConfiguration(?GeneratorConfiguration $configuration, array $classesToGenerate): GeneratorConfiguration
+    {
+        if (null === $configuration) {
+            $configuration = new GeneratorConfiguration([], []);
+        }
+
+        foreach ($classesToGenerate as $className) {
+            $configuration->addClassToGenerate(new ClassToGenerate($configuration, $className));
+        }
+
+        return $configuration;
     }
 }

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -240,6 +240,11 @@ final class SerializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
 
+            case $subType instanceof PropertyTypeUnknown;
+                if ($this->configuration->shouldAssignUnknownArrays()) {
+                    return $this->templating->renderArrayAssign($arrayPath, $modelPath);
+                }
+
             default:
                 throw new \Exception('Unexpected array subtype '.\get_class($subType));
         }

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -240,10 +240,8 @@ final class SerializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
 
-            case $subType instanceof PropertyTypeUnknown;
-                if ($this->configuration->shouldAssignUnknownArrays()) {
-                    return $this->templating->renderArrayAssign($arrayPath, $modelPath);
-                }
+            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAssignUnknownArrays():
+                return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 
             default:
                 throw new \Exception('Unexpected array subtype '.\get_class($subType));

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -240,7 +240,7 @@ final class SerializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
 
-            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAssignUnknownArrays():
+            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
                 return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 
             default:

--- a/tests/Fixtures/UnknownArraySubType.php
+++ b/tests/Fixtures/UnknownArraySubType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class UnknownArraySubType
+{
+    /**
+     * @var array
+     *
+     * @Serializer\Type("array")
+     */
+    public $unknownSubType;
+}

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -281,7 +281,7 @@ class DeserializerGeneratorTest extends SerializerTestCase
     public function testArraysWithUnknownSubType(): void
     {
         $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_UnknownArraySubType';
-        self::generateDeserializer(self::$metadataBuilder, UnknownArraySubType::class, $functionName, ['assign_unknown_arrays' => true]);
+        self::generateDeserializer(self::$metadataBuilder, UnknownArraySubType::class, $functionName, ['allow_generic_arrays' => true]);
 
         $unknownSubtype = ['unknown' => 'type', 'nested' => ['unknown' => 'subtype']];
         $input = [

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -22,6 +22,7 @@ use Tests\Liip\Serializer\Fixtures\NonEmptyConstructor;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
 use Tests\Liip\Serializer\Fixtures\RecursionModel;
+use Tests\Liip\Serializer\Fixtures\UnknownArraySubType;
 use Tests\Liip\Serializer\Fixtures\VirtualProperties;
 
 /**
@@ -275,5 +276,23 @@ class DeserializerGeneratorTest extends SerializerTestCase
         static::assertInstanceOf(PostDeserialize::class, $model);
         static::assertSame('apiString', $model->apiString);
         static::assertSame('post has been called', $model->postCalled);
+    }
+
+    public function testArraysWithUnknownSubType(): void
+    {
+        $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_UnknownArraySubType';
+        self::generateDeserializer(self::$metadataBuilder, UnknownArraySubType::class, $functionName, ['assign_unknown_arrays' => true]);
+
+        $unknownSubtype = ['unknown' => 'type', 'nested' => ['unknown' => 'subtype']];
+        $input = [
+            'unknown_sub_type' => $unknownSubtype,
+        ];
+
+        $list = new UnknownArraySubType();
+        $list->unknownSubType = $unknownSubtype;
+
+        $model = $functionName($input);
+        static::assertInstanceOf(UnknownArraySubType::class, $model);
+        static::assertSame($unknownSubtype, $list->unknownSubType);
     }
 }

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -131,7 +131,7 @@ class SerializerGeneratorTest extends SerializerTestCase
     public function testArraysWithUnknownSubType(): void
     {
         $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_UnknownArraySubType';
-        self::generateSerializers(self::$metadataBuilder, UnknownArraySubType::class, [$functionName], [''], [], ['assign_unknown_arrays' => true]);
+        self::generateSerializers(self::$metadataBuilder, UnknownArraySubType::class, [$functionName], [''], [], ['allow_generic_arrays' => true]);
 
         $list = new UnknownArraySubType();
         $unknownSubtype = ['unknown' => 'type', 'nested' => ['unknown' => 'subtype']];

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -21,6 +21,7 @@ use Tests\Liip\Serializer\Fixtures\Nested;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
 use Tests\Liip\Serializer\Fixtures\RecursionModel;
+use Tests\Liip\Serializer\Fixtures\UnknownArraySubType;
 use Tests\Liip\Serializer\Fixtures\Versions;
 use Tests\Liip\Serializer\Fixtures\VirtualProperties;
 
@@ -121,6 +122,23 @@ class SerializerGeneratorTest extends SerializerTestCase
                 'a' => ['nested_string' => 'nested1'],
                 'b' => ['nested_string' => 'nested2'],
             ],
+        ];
+
+        $data = $functionName($list);
+        static::assertSame($expected, $data);
+    }
+
+    public function testArraysWithUnknownSubType(): void
+    {
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_UnknownArraySubType';
+        self::generateSerializers(self::$metadataBuilder, UnknownArraySubType::class, [$functionName], [''], [], true);
+
+        $list = new UnknownArraySubType();
+        $unknownSubtype = ['unknown' => 'type', 'nested' => ['unknown' => 'subtype']];
+        $list->unknownSubType = $unknownSubtype;
+
+        $expected = [
+            'unknown_sub_type' => $unknownSubtype,
         ];
 
         $data = $functionName($list);

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -131,7 +131,7 @@ class SerializerGeneratorTest extends SerializerTestCase
     public function testArraysWithUnknownSubType(): void
     {
         $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_UnknownArraySubType';
-        self::generateSerializers(self::$metadataBuilder, UnknownArraySubType::class, [$functionName], [''], [], true);
+        self::generateSerializers(self::$metadataBuilder, UnknownArraySubType::class, [$functionName], [''], [], ['assign_unknown_arrays' => true]);
 
         $list = new UnknownArraySubType();
         $unknownSubtype = ['unknown' => 'type', 'nested' => ['unknown' => 'subtype']];

--- a/tests/Unit/SerializerTestCase.php
+++ b/tests/Unit/SerializerTestCase.php
@@ -41,7 +41,7 @@ class SerializerTestCase extends TestCase
         static::assertTrue(\function_exists($functionName));
     }
 
-    protected static function generateSerializers(Builder $metadataBuilder, string $classToGenerate, array $functionNames, array $versions = ['2'], array $groups = []): void
+    protected static function generateSerializers(Builder $metadataBuilder, string $classToGenerate, array $functionNames, array $versions = ['2'], array $groups = [], bool $assignUnknownArrays = false): void
     {
         $templating = new Serialization();
         $configuration = GeneratorConfiguration::createFomArray([
@@ -50,6 +50,7 @@ class SerializerTestCase extends TestCase
             'classes' => [
                 $classToGenerate => [],
             ],
+            'assign_unknown_arrays' => $assignUnknownArrays,
         ]);
         $serializerGenerator = new SerializerGenerator($templating, $configuration, '/tmp');
 

--- a/tests/Unit/SerializerTestCase.php
+++ b/tests/Unit/SerializerTestCase.php
@@ -41,7 +41,7 @@ class SerializerTestCase extends TestCase
         static::assertTrue(\function_exists($functionName));
     }
 
-    protected static function generateSerializers(Builder $metadataBuilder, string $classToGenerate, array $functionNames, array $versions = ['2'], array $groups = [], bool $assignUnknownArrays = false): void
+    protected static function generateSerializers(Builder $metadataBuilder, string $classToGenerate, array $functionNames, array $versions = ['2'], array $groups = [], array $options = []): void
     {
         $templating = new Serialization();
         $configuration = GeneratorConfiguration::createFomArray([
@@ -50,7 +50,7 @@ class SerializerTestCase extends TestCase
             'classes' => [
                 $classToGenerate => [],
             ],
-            'assign_unknown_arrays' => $assignUnknownArrays,
+            'options' => $options,
         ]);
         $serializerGenerator = new SerializerGenerator($templating, $configuration, '/tmp');
 

--- a/tests/Unit/SerializerTestCase.php
+++ b/tests/Unit/SerializerTestCase.php
@@ -28,10 +28,11 @@ class SerializerTestCase extends TestCase
     /**
      * Generate the deserializer for the specified class and make sure the file and function exist.
      */
-    protected static function generateDeserializer(Builder $metadataBuilder, string $classToGenerate, string $functionName): void
+    protected static function generateDeserializer(Builder $metadataBuilder, string $classToGenerate, string $functionName, array $options = []): void
     {
         $templating = new Deserialization();
-        $deserializerGenerator = new DeserializerGenerator($templating, [$classToGenerate], '/tmp');
+        $configuration = GeneratorConfiguration::createFomArray(['classes' => [$classToGenerate => []], 'options' => $options]);
+        $deserializerGenerator = new DeserializerGenerator($templating, [], '/tmp', $configuration);
 
         $deserializerGenerator->generate($metadataBuilder);
 


### PR DESCRIPTION
With this change it is now possible to directly assign an array to its json/model when the type is unknown. This is useful when the structure of the array is dynamic or unknown. 
In order to not break existing logic, a new configuration option `assignUnknownArrays` was added to the generator configuration.