### PR TITLE
Fixed problem when serializing a multidimensional primitive array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 /.php-cs-fixer
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
+
+###> PHPStorm IDE ###
+.idea
+###< PHPStorm IDE ###

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -223,6 +223,11 @@ final class SerializerGenerator
         $subType = $type->getSubType();
 
         switch ($subType) {
+            case $subType instanceof PropertyTypePrimitive:
+            case $subType instanceof PropertyTypeArray && $subType->getSubType() instanceof PropertyTypePrimitive:
+            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
+                return $this->templating->renderArrayAssign($arrayPath, $modelPath);
+
             case $subType instanceof PropertyTypeArray:
                 $innerCode = $this->generateCodeForArray($subType, $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
@@ -230,10 +235,6 @@ final class SerializerGenerator
             case $subType instanceof PropertyTypeClass:
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
-
-            case $subType instanceof PropertyTypePrimitive:
-            case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
-                return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 
             default:
                 throw new \Exception('Unexpected array subtype '.$subType::class);

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -184,17 +184,6 @@ final class SerializerGenerator
         string $modelPropertyPath,
         array $stack
     ): string {
-        if ($type instanceof PropertyTypeArray) {
-            if ($type->getSubType() instanceof PropertyTypePrimitive) {
-                // for arrays of scalars, copy the field even when its an empty array
-                return $this->templating->renderArrayAssign($fieldPath, $modelPropertyPath);
-            }
-
-            // either array or hashmap with second param the type of values
-            // the index works the same whether its numeric or hashmap
-            return $this->generateCodeForArray($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
-        }
-
         switch ($type) {
             case $type instanceof PropertyTypeDateTime:
                 if (null !== $type->getZone()) {
@@ -214,6 +203,9 @@ final class SerializerGenerator
 
             case $type instanceof PropertyTypeClass:
                 return $this->generateCodeForClass($type->getClassMetadata(), $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
+
+            case $type instanceof PropertyTypeArray:
+                return $this->generateCodeForArray($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
             default:
                 throw new \Exception('Unexpected type '.\get_class($type).' at '.$modelPropertyPath);
@@ -240,6 +232,7 @@ final class SerializerGenerator
                 $innerCode = $this->generateCodeForClass($subType->getClassMetadata(), $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
 
+            case $subType instanceof PropertyTypePrimitive:
             case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
                 return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 

--- a/tests/Fixtures/PrimitiveArraySubType.php
+++ b/tests/Fixtures/PrimitiveArraySubType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class PrimitiveArraySubType
+{
+    /**
+     * @Serializer\Type("array<int, array<int>>")
+     */
+    public array $primitivesLists = [];
+}

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -19,6 +19,7 @@ use Tests\Liip\Serializer\Fixtures\ListModel;
 use Tests\Liip\Serializer\Fixtures\Model;
 use Tests\Liip\Serializer\Fixtures\Nested;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
+use Tests\Liip\Serializer\Fixtures\PrimitiveArraySubType;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
 use Tests\Liip\Serializer\Fixtures\RecursionModel;
 use Tests\Liip\Serializer\Fixtures\UnknownArraySubType;
@@ -139,6 +140,23 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
 
         $data = $functionName($list);
+        self::assertSame($expected, $data);
+    }
+
+    public function testArraysWithPrimitiveSubType(): void
+    {
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_PrimitiveArraySubType';
+        self::generateSerializers(self::$metadataBuilder, PrimitiveArraySubType::class, [$functionName], ['']);
+
+        $subject = new PrimitiveArraySubType();
+        $lists = [[1, 2, 3], [4, 5, 6]];
+        $subject->primitivesLists = $lists;
+
+        $expected = [
+            'primitives_lists' => $lists,
+        ];
+
+        $data = $functionName($subject);
         self::assertSame($expected, $data);
     }
 


### PR DESCRIPTION
This MR fixes a problem with the serialization of an multidimensional array for a basic data type. This happened for instance by using JMS type annotation ala `array<string, array<string>>`.