### PR TITLE
Update liip/metadata-parser to latest version and do some housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-      - name: Validate composer.json
-        run: composer validate --strict --no-check-lock
+      - name: Remove dev tools to not interfere with dependencies
+        run: composer remove --dev friendsofphp/php-cs-fixer phpstan/phpstan-phpunit phpstan/phpstan
       - name: Composer cache
         uses: actions/cache@v3
         with:
@@ -34,8 +34,5 @@ jobs:
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
       - name: Install dependencies
         run: composer update ${{ matrix.composer-flags }} --prefer-dist --no-interaction
-      - name: PHPStan
-        if: ${{ matrix.php-version == '7.3' }}
-        run: composer phpstan-all
       - name: Run tests
         run: composer phpunit

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,52 @@
+name: Static
+
+on:
+    push:
+        branches:
+            - '*.x'
+        tags:
+            - '[0-9].[0-9]+'
+    pull_request:
+
+jobs:
+    phpstan:
+        name: "PHPStan"
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code into the workspace
+              uses: actions/checkout@v3
+            - name: Setup PHP 8.2
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+            - name: Composer cache
+              uses: actions/cache@v3
+              with:
+                  path: ${{ env.HOME }}/.composer/cache
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+            - name: Install dependencies
+              run: composer update --prefer-dist --no-interaction
+            - name: PHPStan
+              run: composer phpstan-all
+
+    cs:
+        name: "CS Fixer"
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code into the workspace
+              uses: actions/checkout@v3
+            - name: Setup PHP 8.2
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+            - name: Validate composer.json
+              run: composer validate --strict --no-check-lock
+            - name: Composer cache
+              uses: actions/cache@v3
+              with:
+                  path: ${{ env.HOME }}/.composer/cache
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+            - name: Install dependencies
+              run: composer update --prefer-dist --no-interaction
+            - name: CS Fixer
+              run: composer cs-fixer

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 ###< phpunit/phpunit ###
 
 ###> friendsofphp/php-cs-fixer ###
-/.php_cs
-/.php_cs.cache
+/.php-cs-fixer
+/.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
-$finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-;
+$config = new PhpCsFixer\Config();
 
-return PhpCsFixer\Config::create()
+$config->setFinder(
+    PhpCsFixer\Finder::create()
+        ->in([
+            __DIR__,
+        ]),
+);
+
+return $config
     ->setRiskyAllowed(true)
     ->setRules(
         [
@@ -47,5 +52,4 @@ return PhpCsFixer\Config::create()
             'strict_comparison' => false,
         ]
     )
-    ->setFinder($finder)
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.4.0 (unreleased)
+
+* Increase liip/metadata to `1.1` and drop support for `0.6`
+
 # 2.3.1
 
 * Allow installation with liip/metadata 1.x in addition to 0.6

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "doctrine/collections": "^1.6",
         "friendsofphp/php-cs-fixer": "^3.17.0",
         "jms/serializer": "^1.13 || ^2 || ^3",
-        "phpstan/phpstan": "^0.12.0",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "doctrine/annotations": "^1.10.2",
-        "liip/metadata-parser": "^0.6 || ^1.0",
+        "liip/metadata-parser": "^1.1",
         "pnz/json-exception": "^1.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6",
-        "friendsofphp/php-cs-fixer": "^2.14",
+        "friendsofphp/php-cs-fixer": "^3.17.0",
         "jms/serializer": "^1.13 || ^2 || ^3",
         "phpstan/phpstan": "^0.12.0",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.6.8"
     },
     "autoload": {
         "psr-4": {
@@ -43,7 +43,7 @@
     },
     "scripts": {
         "fix-cs": "vendor/bin/php-cs-fixer fix -v",
-        "cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run --diff --diff-format udiff -v",
+        "cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run --diff -v",
         "phpstan": "vendor/bin/phpstan analyse --no-progress --level 5 src/",
         "phpstan-tests": "vendor/bin/phpstan analyse --no-progress --level 1 -c phpstan.tests.neon tests/",
         "phpstan-all": [

--- a/src/Configuration/ClassToGenerate.php
+++ b/src/Configuration/ClassToGenerate.php
@@ -36,7 +36,7 @@ class ClassToGenerate implements \IteratorAggregate
      */
     private $defaultVersions;
 
-    public function __construct(GeneratorConfiguration $configuration, string $className, ?array $defaultVersions = null)
+    public function __construct(GeneratorConfiguration $configuration, string $className, array $defaultVersions = null)
     {
         $this->configuration = $configuration;
         $this->className = $className;

--- a/src/Configuration/GeneratorConfiguration.php
+++ b/src/Configuration/GeneratorConfiguration.php
@@ -137,7 +137,7 @@ class GeneratorConfiguration implements \IteratorAggregate
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'allow_generic_arrays' => false
+            'allow_generic_arrays' => false,
         ]);
 
         $resolver->setAllowedTypes('allow_generic_arrays', 'boolean');

--- a/src/Configuration/GroupCombination.php
+++ b/src/Configuration/GroupCombination.php
@@ -34,7 +34,7 @@ class GroupCombination
      */
     private $versions;
 
-    public function __construct(ClassToGenerate $containingClass, array $groups, ?array $versions = null)
+    public function __construct(ClassToGenerate $containingClass, array $groups, array $versions = null)
     {
         $this->containingClass = $containingClass;
         $this->groups = $groups;

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -53,7 +53,6 @@ final class DeserializerGenerator
         string $cacheDirectory,
         GeneratorConfiguration $configuration = null
     ) {
-
         $this->templating = $templating;
         $this->cacheDirectory = $cacheDirectory;
         $this->filesystem = new Filesystem();
@@ -62,7 +61,7 @@ final class DeserializerGenerator
 
     public static function buildDeserializerFunctionName(string $className): string
     {
-        return static::FILENAME_PREFIX.'_'.str_replace('\\', '_', $className);
+        return self::FILENAME_PREFIX.'_'.str_replace('\\', '_', $className);
     }
 
     public function generate(Builder $metadataBuilder): void
@@ -86,7 +85,7 @@ final class DeserializerGenerator
             throw new \Exception(sprintf('We currently do not support deserializing when the root class has a non-empty constructor. Class %s', $classMetadata->getClassName()));
         }
 
-        $functionName = static::buildDeserializerFunctionName($classMetadata->getClassName());
+        $functionName = self::buildDeserializerFunctionName($classMetadata->getClassName());
         $arrayPath = new ArrayPath('jsonData');
 
         $code = $this->templating->renderFunction(
@@ -168,7 +167,7 @@ final class DeserializerGenerator
         if ($propertyMetadata->isReadOnly()) {
             return '';
         }
-        
+
         if (Recursion::hasMaxDepthReached($propertyMetadata, $stack)) {
             return '';
         }
@@ -240,7 +239,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForClass($type->getClassMetadata(), $arrayPath, $modelPropertyPath, $stack);
 
             default:
-                throw new \Exception('Unexpected type '.\get_class($type).' at '.$modelPropertyPath);
+                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -273,7 +272,7 @@ final class DeserializerGenerator
                 return $this->templating->renderAssignJsonDataToField((string) $modelPath, (string) $arrayPath);
 
             default:
-                throw new \Exception('Unexpected array subtype '.\get_class($subType));
+                throw new \Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {
@@ -300,9 +299,7 @@ final class DeserializerGenerator
             return '';
         }
 
-        $code = $innerCode . $this->templating->renderArrayCollection((string) $modelPath, (string) $tmpVariable);
-
-        return $code;
+        return $innerCode.$this->templating->renderArrayCollection((string) $modelPath, (string) $tmpVariable);
     }
 
     private function createGeneratorConfiguration(?GeneratorConfiguration $configuration, array $classesToGenerate): GeneratorConfiguration

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -35,19 +35,6 @@ final class DeserializerGenerator
     private $filesystem;
 
     /**
-     * This is a list of fqn classnames
-     *
-     * I.e.
-     *
-     * [
-     *    Product::class,
-     * ];
-     *
-     * @var array
-     */
-    private $classesToGenerate;
-
-    /**
      * @var string
      */
     private $cacheDirectory;
@@ -58,7 +45,7 @@ final class DeserializerGenerator
     private $configuration;
 
     /**
-     * @param string[] $classesToGenerate
+     * @param string[] $classesToGenerate This is a list of fqn classnames
      */
     public function __construct(
         Deserialization $templating,

--- a/src/Path/ModelPath.php
+++ b/src/Path/ModelPath.php
@@ -41,7 +41,7 @@ final class ModelPath
 
     public static function indexVariable(string $path): self
     {
-        return new self('index'.\mb_strlen($path));
+        return new self('index'.mb_strlen($path));
     }
 
     public function withPath(string $component): self

--- a/src/Path/ModelPath.php
+++ b/src/Path/ModelPath.php
@@ -25,7 +25,7 @@ final class ModelPath
     }
 
     /**
-     * @var string[]
+     * @param string[] $components
      */
     public static function tempVariable(array $components): self
     {

--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -19,7 +19,6 @@ abstract class Recursion
         return false;
     }
 
-
     public static function hasMaxDepthReached(PropertyMetadata $propertyMetadata, array $stack): bool
     {
         if (null === $propertyMetadata->getMaxDepth()) {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -34,7 +34,7 @@ final class Serializer implements SerializerInterface
      * Serializing primitive types is not currently implemented and will lead
      * to an UnsupportedTypeException.
      */
-    public function serialize($data, string $format, ?Context $context = null): string
+    public function serialize($data, string $format, Context $context = null): string
     {
         if ('json' !== $format) {
             throw new UnsupportedFormatException('Liip serializer only supports JSON for now');
@@ -43,7 +43,7 @@ final class Serializer implements SerializerInterface
         try {
             return Json::encode($this->objectToArray($data, true, $context), \JSON_UNESCAPED_SLASHES);
         } catch (\JsonException $e) {
-            throw new Exception(sprintf('Failed to JSON encode data for %s. This is not supposed to happen.', \is_object($data) ? \get_class($data) : \gettype($data)), 0, $e);
+            throw new Exception(sprintf('Failed to JSON encode data for %s. This is not supposed to happen.', \is_object($data) ? $data::class : \gettype($data)), 0, $e);
         }
     }
 
@@ -53,7 +53,7 @@ final class Serializer implements SerializerInterface
      * Version or groups are currently not implemented for deserialization and
      * passing a context with one of those values set will lead to an Exception.
      */
-    public function deserialize(string $data, string $type, string $format, ?Context $context = null)
+    public function deserialize(string $data, string $type, string $format, Context $context = null): mixed
     {
         if ('json' !== $format) {
             throw new UnsupportedFormatException('Liip serializer only supports JSON for now');
@@ -74,7 +74,7 @@ final class Serializer implements SerializerInterface
      * Serializing primitive types is not currently implemented and will lead
      * to an UnsupportedTypeException.
      */
-    public function toArray($data, ?Context $context = null): array
+    public function toArray($data, Context $context = null): array
     {
         return $this->objectToArray($data, false, $context);
     }
@@ -85,7 +85,7 @@ final class Serializer implements SerializerInterface
      * Version or groups are currently not implemented for deserialization and
      * passing a context with one of those values set will lead to an Exception.
      */
-    public function fromArray(array $data, string $type, ?Context $context = null)
+    public function fromArray(array $data, string $type, Context $context = null): mixed
     {
         return $this->arrayToObject($data, $type, $context);
     }
@@ -119,7 +119,7 @@ final class Serializer implements SerializerInterface
         if (!\is_object($data)) {
             throw new UnsupportedTypeException('The Liip Serializer only works for objects');
         }
-        $type = \get_class($data);
+        $type = $data::class;
         $groups = [];
         $version = null;
         if ($context) {
@@ -130,7 +130,7 @@ final class Serializer implements SerializerInterface
         }
         $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version ? (string) $version : null, $groups);
         $filename = sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-        if (!\file_exists($filename)) {
+        if (!file_exists($filename)) {
             throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
         }
 

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -59,7 +59,7 @@ final class SerializerGenerator
 
     public static function buildSerializerFunctionName(string $className, ?string $apiVersion, array $serializerGroups): string
     {
-        $functionName = static::FILENAME_PREFIX.'_'.$className;
+        $functionName = self::FILENAME_PREFIX.'_'.$className;
         if (\count($serializerGroups)) {
             $functionName .= '_'.implode('_', $serializerGroups);
         }
@@ -114,7 +114,7 @@ final class SerializerGenerator
         ClassMetadata $classMetadata
     ): void {
         sort($serializerGroups);
-        $functionName = static::buildSerializerFunctionName($className, $apiVersion, $serializerGroups);
+        $functionName = self::buildSerializerFunctionName($className, $apiVersion, $serializerGroups);
 
         $code = $this->templating->renderFunction(
             $functionName,
@@ -216,7 +216,7 @@ final class SerializerGenerator
                 return $this->generateCodeForClass($type->getClassMetadata(), $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
             default:
-                throw new \Exception('Unexpected type '.\get_class($type).' at '.$modelPropertyPath);
+                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -228,7 +228,7 @@ final class SerializerGenerator
         string $modelPath,
         array $stack
     ): string {
-        $index = '$index'.\mb_strlen($arrayPath);
+        $index = '$index'.mb_strlen($arrayPath);
         $subType = $type->getSubType();
 
         switch ($subType) {
@@ -244,7 +244,7 @@ final class SerializerGenerator
                 return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 
             default:
-                throw new \Exception('Unexpected array subtype '.\get_class($subType));
+                throw new \Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -22,13 +22,13 @@ interface SerializerInterface
      * @param string  $format  The target format to serialize to
      * @param Context $context Additional configuration for serialization
      *
+     * @return string Encoded data according to $format
+     *
      * @throws Exception                  if anything else goes wrong
      * @throws UnsupportedFormatException if $format is not supported
      * @throws UnsupportedTypeException   if no generated function is available for the class of $data
-     *
-     * @return string Encoded data according to $format
      */
-    public function serialize($data, string $format, ?Context $context = null): string;
+    public function serialize($data, string $format, Context $context = null): string;
 
     /**
      * Convert a string representation to an object.
@@ -38,13 +38,13 @@ interface SerializerInterface
      * @param string  $format  Encoding of $data
      * @param Context $context Additional configuration for deserialization
      *
+     * @return mixed Object of $type
+     *
      * @throws Exception                  if anything else goes wrong
      * @throws UnsupportedFormatException if $format is not supported
      * @throws UnsupportedTypeException   if there is no generated function available for $type
-     *
-     * @return mixed Object of $type
      */
-    public function deserialize(string $data, string $type, string $format, ?Context $context = null);
+    public function deserialize(string $data, string $type, string $format, Context $context = null): mixed;
 
     /**
      * Convert an object to an array.
@@ -52,12 +52,12 @@ interface SerializerInterface
      * @param mixed   $data    The model to convert to an array.
      * @param Context $context Additional configuration for serialization
      *
+     * @return array Data represented as an array
+     *
      * @throws Exception                if anything else goes wrong
      * @throws UnsupportedTypeException if no generated function is available for the class of $data
-     *
-     * @return array Data represented as an array
      */
-    public function toArray($data, ?Context $context = null): array;
+    public function toArray($data, Context $context = null): array;
 
     /**
      * Convert an array to an object.
@@ -66,10 +66,10 @@ interface SerializerInterface
      * @param string  $type    The target type to deserialize to
      * @param Context $context Additional configuration for deserialization
      *
+     * @return mixed Object of $type
+     *
      * @throws Exception                if anything else goes wrong
      * @throws UnsupportedTypeException if there is no generated function available for $type
-     *
-     * @return mixed Object of $type
      */
-    public function fromArray(array $data, string $type, ?Context $context = null);
+    public function fromArray(array $data, string $type, Context $context = null): mixed;
 }

--- a/src/Template/Serialization.php
+++ b/src/Template/Serialization.php
@@ -57,7 +57,7 @@ EOT;
 if ({{propertyAccessor}} instanceof \Doctrine\Common\Collections\Collection) {
     {{indexVariable}}Array = {{propertyAccessor}}->toArray();
 }
-    
+
 $jsonData{{jsonPath}} = [];
 foreach (array_keys({{indexVariable}}Array) as {{indexVariable}}) {
     {{code}}
@@ -78,7 +78,7 @@ if (0 === \count({{propertyAccessor}})) {
     if ({{propertyAccessor}} instanceof \Doctrine\Common\Collections\Collection) {
         {{indexVariable}}Array = {{propertyAccessor}}->toArray();
     }
-    
+
     foreach (array_keys({{indexVariable}}Array) as {{indexVariable}}) {
         {{code}}
     }

--- a/src/Template/Serialization.php
+++ b/src/Template/Serialization.php
@@ -85,10 +85,6 @@ if (0 === \count({{propertyAccessor}})) {
 }
 
 EOT;
-    private const TMPL_LOOP_HASHMAP_EMPTY = <<<'EOT'
-$jsonData{{jsonPath}} = $emptyHashmap;
-
-EOT;
 
     private const TMPL_GETTER = '{{modelPath}}->{{method}}()';
 

--- a/tests/Fixtures/AccessorOrder.php
+++ b/tests/Fixtures/AccessorOrder.php
@@ -17,6 +17,7 @@ class AccessorOrder
 {
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Until("1")
      */
     public $apiString2;
@@ -28,7 +29,9 @@ class AccessorOrder
 
     /**
      * @var int
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\Until("1")
      */
     public $totalHits;
@@ -42,8 +45,11 @@ class AccessorOrder
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\VirtualProperty
+     *
      * @Serializer\SerializedName("api_string2")
+     *
      * @Serializer\Since("2")
      */
     public function getApiString2(): string
@@ -53,8 +59,11 @@ class AccessorOrder
 
     /**
      * @Serializer\Type("integer")
+     *
      * @Serializer\VirtualProperty
+     *
      * @Serializer\SerializedName("total_hits")
+     *
      * @Serializer\Since("2")
      */
     public function getTotalHits(): int

--- a/tests/Fixtures/AccessorOrderInherit.php
+++ b/tests/Fixtures/AccessorOrderInherit.php
@@ -13,6 +13,7 @@ class AccessorOrderInherit extends AccessorOrder
 {
     /**
      * @var string
+     *
      * @Serializer\Type("string")
      */
     public $apiString0;

--- a/tests/Fixtures/ContainsPrivateProperty.php
+++ b/tests/Fixtures/ContainsPrivateProperty.php
@@ -20,6 +20,7 @@ class ContainsPrivateProperty
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Groups({"api"})
      */
     public $apiString;

--- a/tests/Fixtures/ListModel.php
+++ b/tests/Fixtures/ListModel.php
@@ -30,6 +30,7 @@ class ListModel
      * @var Nested[]
      *
      * @Serializer\Type("array<Tests\Liip\Serializer\Fixtures\Nested>")
+     *
      * @Serializer\Accessor("getOptionalList")
      */
     public $optionalList;

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -10,12 +10,14 @@ class Model
 {
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Groups({"api"})
      */
     public $apiString;
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Groups({"details"})
      */
     public $detailString;

--- a/tests/Fixtures/Nested.php
+++ b/tests/Fixtures/Nested.php
@@ -10,13 +10,16 @@ class Nested
 {
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Groups({"api"})
      */
     public $nestedString;
 
     /**
      * @Serializer\Type("array<string>")
+     *
      * @Serializer\Groups({"api"})
+     *
      * @Serializer\Accessor(getter="getArray")
      */
     public $array;

--- a/tests/Fixtures/PrivateProperty.php
+++ b/tests/Fixtures/PrivateProperty.php
@@ -10,12 +10,14 @@ class PrivateProperty
 {
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Accessor(getter="getExtra", setter="setExtra")
      */
     protected $extra;
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Accessor(getter="getApiString", setter="setApiString")
      */
     private $apiString;

--- a/tests/Fixtures/RecursionModel.php
+++ b/tests/Fixtures/RecursionModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Liip\Serializer\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;
@@ -13,6 +15,7 @@ class RecursionModel
 
     /**
      * @Serializer\MaxDepth(2)
+     *
      * @Serializer\Type("Tests\Liip\Serializer\Fixtures\RecursionModel")
      */
     public $recursion;

--- a/tests/Fixtures/UnknownArraySubType.php
+++ b/tests/Fixtures/UnknownArraySubType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Liip\Serializer\Fixtures;
 
 use JMS\Serializer\Annotation as Serializer;

--- a/tests/Fixtures/Versions.php
+++ b/tests/Fixtures/Versions.php
@@ -10,26 +10,32 @@ class Versions
 {
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Until("2")
      */
     public $old;
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Until("2")
      */
     public $changed;
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Since("3")
      */
     public $new;
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\Since("3")
+     *
      * @Serializer\VirtualProperty
+     *
      * @Serializer\SerializedName("changed")
      */
     public function getChangedInV3()

--- a/tests/Fixtures/VirtualProperties.php
+++ b/tests/Fixtures/VirtualProperties.php
@@ -15,7 +15,9 @@ class VirtualProperties
 
     /**
      * @Serializer\Type("string")
+     *
      * @Serializer\VirtualProperty
+     *
      * @Serializer\SerializedName("api_string_virtual")
      */
     public function getApiString()

--- a/tests/Unit/ContextTest.php
+++ b/tests/Unit/ContextTest.php
@@ -16,6 +16,6 @@ class ContextTest extends TestCase
     {
         $context = new Context();
         $context->setGroups(['a', 'b', 'a']);
-        static::assertSame(['a', 'b'], $context->getGroups());
+        self::assertSame(['a', 'b'], $context->getGroups());
     }
 }

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -60,18 +60,18 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var Model $model */
         $model = $functionName($input);
-        static::assertInstanceOf(Model::class, $model);
-        static::assertSame('api', $model->apiString);
-        static::assertSame('details', $model->detailString);
-        static::assertNull($model->unAnnotated);
-        static::assertInstanceOf(Nested::class, $model->nestedField);
-        static::assertSame('nested', $model->nestedField->nestedString);
-        static::assertInstanceOf(\DateTime::class, $model->date);
-        static::assertSame('2018-08-03', $model->date->format('Y-m-d'));
-        static::assertInstanceOf(\DateTime::class, $model->dateWithFormat);
-        static::assertSame('2018-08-04', $model->dateWithFormat->format('Y-m-d'));
-        static::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
-        static::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
+        self::assertInstanceOf(Model::class, $model);
+        self::assertSame('api', $model->apiString);
+        self::assertSame('details', $model->detailString);
+        self::assertNull($model->unAnnotated);
+        self::assertInstanceOf(Nested::class, $model->nestedField);
+        self::assertSame('nested', $model->nestedField->nestedString);
+        self::assertInstanceOf(\DateTime::class, $model->date);
+        self::assertSame('2018-08-03', $model->date->format('Y-m-d'));
+        self::assertInstanceOf(\DateTime::class, $model->dateWithFormat);
+        self::assertSame('2018-08-04', $model->dateWithFormat->format('Y-m-d'));
+        self::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
+        self::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
     }
 
     public function testLists(): void
@@ -94,28 +94,27 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var ListModel $model */
         $model = $functionName($input);
-        static::assertInstanceOf(ListModel::class, $model);
-        static::assertSame(['a', 'b'], $model->array);
-        static::assertIsArray($model->listNested);
-        static::assertCount(2, $model->listNested);
+        self::assertInstanceOf(ListModel::class, $model);
+        self::assertSame(['a', 'b'], $model->array);
+        self::assertIsArray($model->listNested);
+        self::assertCount(2, $model->listNested);
 
         foreach ($model->listNested as $index => $nested) {
-            static::assertInstanceOf(Nested::class, $nested);
-            static::assertSame('nested'.($index + 1), $nested->nestedString);
+            self::assertInstanceOf(Nested::class, $nested);
+            self::assertSame('nested'.($index + 1), $nested->nestedString);
         }
 
-        static::assertInstanceOf(ArrayCollection::class, $model->collection);
-        static::assertCount(2, $model->collection);
-        static::assertSame(['entry', 'second entry'], $model->collection->toArray());
+        self::assertInstanceOf(ArrayCollection::class, $model->collection);
+        self::assertCount(2, $model->collection);
+        self::assertSame(['entry', 'second entry'], $model->collection->toArray());
 
-        static::assertInstanceOf(ArrayCollection::class, $model->collectionNested);
-        static::assertCount(2, $model->collectionNested);
-        static::assertArrayHasKey('first', $model->collectionNested);
-        static::assertSame('nested3', $model->collectionNested['first']->nestedString);
+        self::assertInstanceOf(ArrayCollection::class, $model->collectionNested);
+        self::assertCount(2, $model->collectionNested);
+        self::assertArrayHasKey('first', $model->collectionNested);
+        self::assertSame('nested3', $model->collectionNested['first']->nestedString);
 
-        static::assertArrayHasKey('second', $model->collectionNested);
-        static::assertSame('nested4', $model->collectionNested['second']->nestedString);
-
+        self::assertArrayHasKey('second', $model->collectionNested);
+        self::assertSame('nested4', $model->collectionNested['second']->nestedString);
     }
 
     public function testRecursion(): void
@@ -124,7 +123,7 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::generateDeserializer(self::$metadataBuilder, RecursionModel::class, $functionName);
 
         $input = [
-            'property'=> 'property',
+            'property' => 'property',
             'recursion' => [
                 'property' => 'recursive property',
                 'recursion' => [
@@ -138,15 +137,15 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var RecursionModel $model */
         $model = $functionName($input);
-        static::assertInstanceOf(RecursionModel::class, $model);
-        static::assertSame('property', $model->property);
-        static::assertInstanceOf(RecursionModel::class, $model->recursion);
+        self::assertInstanceOf(RecursionModel::class, $model);
+        self::assertSame('property', $model->property);
+        self::assertInstanceOf(RecursionModel::class, $model->recursion);
 
-        static::assertSame('recursive property', $model->recursion->property);
-        static::assertInstanceOf(RecursionModel::class, $model->recursion->recursion);
+        self::assertSame('recursive property', $model->recursion->property);
+        self::assertInstanceOf(RecursionModel::class, $model->recursion->recursion);
 
-        static::assertSame('recursive recursive property', $model->recursion->recursion->property);
-        static::assertNull($model->recursion->recursion->recursion);
+        self::assertSame('recursive recursive property', $model->recursion->recursion->property);
+        self::assertNull($model->recursion->recursion->recursion);
     }
 
     /**
@@ -163,8 +162,8 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var FloatProperty $model */
         $model = $functionName($input);
-        static::assertInstanceOf(FloatProperty::class, $model);
-        static::assertSame(1.0, $model->number);
+        self::assertInstanceOf(FloatProperty::class, $model);
+        self::assertSame(1.0, $model->number);
     }
 
     public function testPrivateProperty(): void
@@ -179,9 +178,9 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var PrivateProperty $model */
         $model = $functionName($input);
-        static::assertInstanceOf(PrivateProperty::class, $model);
-        static::assertSame('apiString_setter', $model->getApiString());
-        static::assertSame('More Info', $model->getExtra());
+        self::assertInstanceOf(PrivateProperty::class, $model);
+        self::assertSame('apiString_setter', $model->getApiString());
+        self::assertSame('More Info', $model->getExtra());
     }
 
     public function testInheritance(): void
@@ -196,9 +195,9 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var Inheritance $model */
         $model = $functionName($input);
-        static::assertInstanceOf(Inheritance::class, $model);
-        static::assertSame('apiString_setter', $model->getApiString());
-        static::assertSame('More Info', $model->getExtra());
+        self::assertInstanceOf(Inheritance::class, $model);
+        self::assertSame('apiString_setter', $model->getApiString());
+        self::assertSame('More Info', $model->getExtra());
     }
 
     public function testNonEmptyConstructorRoot(): void
@@ -223,12 +222,12 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var ContainsNonEmptyConstructor $model */
         $model = $functionName($input);
-        static::assertInstanceOf(ContainsNonEmptyConstructor::class, $model);
+        self::assertInstanceOf(ContainsNonEmptyConstructor::class, $model);
         $child = $model->child;
-        static::assertInstanceOf(NonEmptyConstructor::class, $child);
-        static::assertSame('apiString', $child->getApiString());
-        static::assertSame('optional', $child->getOptional());
-        static::assertSame(['foo', 'bar'], $child->getOnlyArgument());
+        self::assertInstanceOf(NonEmptyConstructor::class, $child);
+        self::assertSame('apiString', $child->getApiString());
+        self::assertSame('optional', $child->getOptional());
+        self::assertSame(['foo', 'bar'], $child->getOnlyArgument());
 
         $input = [
             'child' => [
@@ -238,12 +237,12 @@ class DeserializerGeneratorTest extends SerializerTestCase
         ];
         /** @var ContainsNonEmptyConstructor $model */
         $model = $functionName($input);
-        static::assertInstanceOf(ContainsNonEmptyConstructor::class, $model);
+        self::assertInstanceOf(ContainsNonEmptyConstructor::class, $model);
         $child = $model->child;
-        static::assertInstanceOf(NonEmptyConstructor::class, $child);
-        static::assertSame('apiString', $child->getApiString());
-        static::assertSame('custom', $child->getOptional());
-        static::assertSame(['foo', 'bar'], $child->getOnlyArgument());
+        self::assertInstanceOf(NonEmptyConstructor::class, $child);
+        self::assertSame('apiString', $child->getApiString());
+        self::assertSame('custom', $child->getOptional());
+        self::assertSame(['foo', 'bar'], $child->getOnlyArgument());
     }
 
     public function testVirtualProperties(): void
@@ -258,8 +257,8 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var VirtualProperties $model */
         $model = $functionName($input);
-        static::assertInstanceOf(VirtualProperties::class, $model);
-        static::assertSame('apiString', $model->apiString);
+        self::assertInstanceOf(VirtualProperties::class, $model);
+        self::assertSame('apiString', $model->apiString);
     }
 
     public function testPostDeserialize(): void
@@ -273,9 +272,9 @@ class DeserializerGeneratorTest extends SerializerTestCase
 
         /** @var PostDeserialize $model */
         $model = $functionName($input);
-        static::assertInstanceOf(PostDeserialize::class, $model);
-        static::assertSame('apiString', $model->apiString);
-        static::assertSame('post has been called', $model->postCalled);
+        self::assertInstanceOf(PostDeserialize::class, $model);
+        self::assertSame('apiString', $model->apiString);
+        self::assertSame('post has been called', $model->postCalled);
     }
 
     public function testArraysWithUnknownSubType(): void
@@ -292,7 +291,7 @@ class DeserializerGeneratorTest extends SerializerTestCase
         $list->unknownSubType = $unknownSubtype;
 
         $model = $functionName($input);
-        static::assertInstanceOf(UnknownArraySubType::class, $model);
-        static::assertSame($unknownSubtype, $list->unknownSubType);
+        self::assertInstanceOf(UnknownArraySubType::class, $model);
+        self::assertSame($unknownSubtype, $list->unknownSubType);
     }
 }

--- a/tests/Unit/Path/ArrayPathTest.php
+++ b/tests/Unit/Path/ArrayPathTest.php
@@ -16,7 +16,7 @@ class ArrayPathTest extends TestCase
     {
         $path = new ArrayPath('data');
 
-        static::assertSame('$data', (string) $path);
+        self::assertSame('$data', (string) $path);
     }
 
     public function testNested(): void
@@ -25,7 +25,7 @@ class ArrayPathTest extends TestCase
         $path = $path->withFieldName('property1');
         $path = $path->withFieldName('property2');
 
-        static::assertSame('$data[\'property1\'][\'property2\']', (string) $path);
+        self::assertSame('$data[\'property1\'][\'property2\']', (string) $path);
     }
 
     public function testNestedAsVariable(): void
@@ -34,6 +34,6 @@ class ArrayPathTest extends TestCase
         $path = $path->withVariable('$property1');
         $path = $path->withVariable('$property2');
 
-        static::assertSame('$data[$property1][$property2]', (string) $path);
+        self::assertSame('$data[$property1][$property2]', (string) $path);
     }
 }

--- a/tests/Unit/Path/ModelPathTest.php
+++ b/tests/Unit/Path/ModelPathTest.php
@@ -16,7 +16,7 @@ class ModelPathTest extends TestCase
     {
         $path = new ModelPath('model');
 
-        static::assertSame('$model', (string) $path);
+        self::assertSame('$model', (string) $path);
     }
 
     public function testNested(): void
@@ -25,7 +25,7 @@ class ModelPathTest extends TestCase
         $path = $path->withPath('property1');
         $path = $path->withPath('property2');
 
-        static::assertSame('$model->property1->property2', (string) $path);
+        self::assertSame('$model->property1->property2', (string) $path);
     }
 
     public function testArrayWithString(): void
@@ -34,7 +34,7 @@ class ModelPathTest extends TestCase
         $path = $path->withPath('property1');
         $path = $path->withArray('\'property2\'');
 
-        static::assertSame('$model->property1[\'property2\']', (string) $path);
+        self::assertSame('$model->property1[\'property2\']', (string) $path);
     }
 
     public function testArrayWithVariable(): void
@@ -43,7 +43,7 @@ class ModelPathTest extends TestCase
         $path = $path->withPath('property1');
         $path = $path->withArray('$index');
 
-        static::assertSame('$model->property1[$index]', (string) $path);
+        self::assertSame('$model->property1[$index]', (string) $path);
     }
 
     public function testArrayNested(): void
@@ -54,6 +54,6 @@ class ModelPathTest extends TestCase
         $path = $path->withArray('\'property3\'');
         $path = $path->withPath('property4');
 
-        static::assertSame('$model->property1[\'property2\'][\'property3\']->property4', (string) $path);
+        self::assertSame('$model->property1[\'property2\'][\'property3\']->property4', (string) $path);
     }
 }

--- a/tests/Unit/SerializationContextTest.php
+++ b/tests/Unit/SerializationContextTest.php
@@ -15,15 +15,15 @@ class SerializationContextTest extends TestCase
     public function testEmpty(): void
     {
         $context = new Context();
-        static::assertNull($context->getVersion());
-        static::assertCount(0, $context->getGroups());
+        self::assertNull($context->getVersion());
+        self::assertCount(0, $context->getGroups());
     }
 
     public function testSetVersion(): void
     {
         $context = new Context();
         $context->setVersion('3');
-        static::assertSame('3', $context->getVersion());
+        self::assertSame('3', $context->getVersion());
     }
 
     public function testSetGroups(): void
@@ -31,6 +31,6 @@ class SerializationContextTest extends TestCase
         $context = new Context();
         $context->setGroups(['a', 'b', 'c']);
 
-        static::assertSame(['a', 'b', 'c'], $context->getGroups());
+        self::assertSame(['a', 'b', 'c'], $context->getGroups());
     }
 }

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -73,20 +73,20 @@ class SerializerGeneratorTest extends SerializerTestCase
             'date_immutable' => '2016-06-01T00:00:00+0200',
         ];
         $data = $functionNoGroups($model);
-        static::assertSame($expected, $data, 'no groups specified');
+        self::assertSame($expected, $data, 'no groups specified');
 
         $expected = [
             'api_string' => 'api',
         ];
         $data = $functionApi($model);
-        static::assertSame($expected, $data, 'group api');
+        self::assertSame($expected, $data, 'group api');
 
         $expected = [
             'api_string' => 'api',
             'detail_string' => 'details',
         ];
         $data = $functionApiDetails($model);
-        static::assertSame($expected, $data, 'groups api and details');
+        self::assertSame($expected, $data, 'groups api and details');
     }
 
     public function testArrays(): void
@@ -125,7 +125,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
 
         $data = $functionName($list);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testArraysWithUnknownSubType(): void
@@ -142,7 +142,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
 
         $data = $functionName($list);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testRecursions(): void
@@ -160,7 +160,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model->recursion->recursion->recursion->property = 'recursive recursive recursive property';
 
         $expected = [
-            'property'=> 'property',
+            'property' => 'property',
             'recursion' => [
                 'property' => 'recursive property',
                 'recursion' => [
@@ -170,7 +170,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
 
         $data = $functionName($model);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testEmptyModel(): void
@@ -181,8 +181,8 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model = new Model();
         $data = $functionName($model);
 
-        static::assertInstanceOf(\stdClass::class, $data);
-        static::assertCount(0, get_object_vars($data));
+        self::assertInstanceOf(\stdClass::class, $data);
+        self::assertCount(0, get_object_vars($data));
     }
 
     public function testEmptyModelNotUsingStdClass(): void
@@ -193,7 +193,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model = new Model();
         $data = $functionName($model, false);
 
-        static::assertSame([], $data);
+        self::assertSame([], $data);
     }
 
     public function testDateTimeWithFormat(): void
@@ -205,7 +205,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model->dateWithFormat = new \DateTime('2020-04-22 10:11:12');
         $data = $functionName($model);
 
-        static::assertSame(['date_with_format' => '2020-04-22'], $data);
+        self::assertSame(['date_with_format' => '2020-04-22'], $data);
     }
 
     /**
@@ -222,14 +222,14 @@ class SerializerGeneratorTest extends SerializerTestCase
         $list->listNested = [];
         $data = $functionName($list);
 
-        static::assertIsArray($data);
-        static::assertArrayHasKey('array', $data);
-        static::assertSame([], $data['array']);
-        static::assertArrayHasKey('list_nested', $data);
-        static::assertSame([], $data['list_nested']);
-        static::assertArrayHasKey('hashmap', $data);
-        static::assertInstanceOf(\stdClass::class, $data['hashmap']);
-        static::assertCount(0, get_object_vars($data['hashmap']));
+        self::assertIsArray($data);
+        self::assertArrayHasKey('array', $data);
+        self::assertSame([], $data['array']);
+        self::assertArrayHasKey('list_nested', $data);
+        self::assertSame([], $data['list_nested']);
+        self::assertArrayHasKey('hashmap', $data);
+        self::assertInstanceOf(\stdClass::class, $data['hashmap']);
+        self::assertCount(0, get_object_vars($data['hashmap']));
     }
 
     public function testEmptyArrayNotUsingStdClass(): void
@@ -243,13 +243,13 @@ class SerializerGeneratorTest extends SerializerTestCase
         $list->listNested = [];
         $data = $functionName($list, false);
 
-        static::assertIsArray($data);
-        static::assertArrayHasKey('array', $data);
-        static::assertSame([], $data['array']);
-        static::assertArrayHasKey('list_nested', $data);
-        static::assertSame([], $data['list_nested']);
-        static::assertArrayHasKey('hashmap', $data);
-        static::assertSame([], $data['hashmap']);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('array', $data);
+        self::assertSame([], $data['array']);
+        self::assertArrayHasKey('list_nested', $data);
+        self::assertSame([], $data['list_nested']);
+        self::assertArrayHasKey('hashmap', $data);
+        self::assertSame([], $data['hashmap']);
     }
 
     public function testPrivateProperty(): void
@@ -266,7 +266,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'api_string' => 'apiString_setter',
         ];
         $data = $functionName($model);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testInheritance(): void
@@ -283,7 +283,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'api_string' => 'apiString_setter',
         ];
         $data = $functionName($model);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testNullFieldWithGetter(): void
@@ -298,7 +298,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'api_string' => 'api string',
         ];
         $data = $functionName($model);
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testVirtualProperties(): void
@@ -315,7 +315,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
         $data = $functionName($model);
 
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     /**
@@ -334,8 +334,8 @@ class SerializerGeneratorTest extends SerializerTestCase
         ];
         $data = $functionName($model);
 
-        static::assertSame($expected, $data);
-        static::assertNull($model->postCalled);
+        self::assertSame($expected, $data);
+        self::assertNull($model->postCalled);
     }
 
     public function testAccessorOrder(): void
@@ -353,7 +353,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'api_string1' => 'apiString1',
         ];
 
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testAccessorOrderInherit(): void
@@ -372,7 +372,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'api_string0' => 'apiString0',
         ];
 
-        static::assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testVersioning(): void
@@ -395,28 +395,28 @@ class SerializerGeneratorTest extends SerializerTestCase
             'changed' => 'changed',
         ];
         $data = $functionV1($model);
-        static::assertSame($expected, $data, 'version 1');
+        self::assertSame($expected, $data, 'version 1');
 
         $expected = [
             'old' => 'old',
             'changed' => 'changed',
         ];
         $data = $functionV2($model);
-        static::assertSame($expected, $data, 'version 2');
+        self::assertSame($expected, $data, 'version 2');
 
         $expected = [
             'changed' => 'CHANGED',
             'new' => 'new',
         ];
         $data = $functionV3($model);
-        static::assertSame($expected, $data, 'version 3');
+        self::assertSame($expected, $data, 'version 3');
 
         $expected = [
             'changed' => 'CHANGED',
             'new' => 'new',
         ];
         $data = $functionV4($model);
-        static::assertSame($expected, $data, 'version 4');
+        self::assertSame($expected, $data, 'version 4');
 
         $expected = [
             'old' => 'old',
@@ -424,7 +424,7 @@ class SerializerGeneratorTest extends SerializerTestCase
             'new' => 'new',
         ];
         $data = $function($model);
-        static::assertSame($expected, $data, 'no version');
+        self::assertSame($expected, $data, 'no version');
     }
 
     public function testInaccessibleProperty(): void

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -26,7 +26,7 @@ class SerializerTest extends TestCase
         $context->setVersion('2');
         $context->setGroups(['api']);
         $json = $transform->serialize(new SerializerModel(), 'json', $context);
-        static::assertSame('{"seen":true}', $json);
+        self::assertSame('{"seen":true}', $json);
     }
 
     public function testSerializeFailOnFormat(): void
@@ -74,7 +74,7 @@ class SerializerTest extends TestCase
         $context->setVersion('2');
         $context->setGroups(['api']);
         $json = $transform->toArray(new SerializerModel(), $context);
-        static::assertSame(['seen' => true], $json);
+        self::assertSame(['seen' => true], $json);
     }
 
     public function testToArrayNoContext(): void
@@ -82,7 +82,7 @@ class SerializerTest extends TestCase
         $transform = new Serializer(__DIR__.'/../Fixtures');
 
         $json = $transform->toArray(new SerializerModel());
-        static::assertSame(['all' => true], $json);
+        self::assertSame(['all' => true], $json);
     }
 
     public function testDeserialize(): void
@@ -90,8 +90,8 @@ class SerializerTest extends TestCase
         $transform = new Serializer(__DIR__.'/../Fixtures');
 
         $data = $transform->deserialize('[]', SerializerModel::class, 'json');
-        static::assertInstanceOf(SerializerModel::class, $data);
-        static::assertSame('deserializer', $data->field);
+        self::assertInstanceOf(SerializerModel::class, $data);
+        self::assertSame('deserializer', $data->field);
     }
 
     public function testDeserializeFailOnFormat(): void
@@ -136,7 +136,7 @@ class SerializerTest extends TestCase
         $transform = new Serializer(__DIR__.'/../Fixtures');
 
         $data = $transform->fromArray([], SerializerModel::class);
-        static::assertInstanceOf(SerializerModel::class, $data);
-        static::assertSame('deserializer', $data->field);
+        self::assertInstanceOf(SerializerModel::class, $data);
+        self::assertSame('deserializer', $data->field);
     }
 }

--- a/tests/Unit/SerializerTestCase.php
+++ b/tests/Unit/SerializerTestCase.php
@@ -37,9 +37,9 @@ class SerializerTestCase extends TestCase
         $deserializerGenerator->generate($metadataBuilder);
 
         $filePath = '/tmp/'.$functionName.'.php';
-        static::assertFileExists($filePath);
+        self::assertFileExists($filePath);
         require_once $filePath;
-        static::assertTrue(\function_exists($functionName));
+        self::assertTrue(\function_exists($functionName));
     }
 
     protected static function generateSerializers(Builder $metadataBuilder, string $classToGenerate, array $functionNames, array $versions = ['2'], array $groups = [], array $options = []): void
@@ -59,9 +59,9 @@ class SerializerTestCase extends TestCase
 
         foreach ($functionNames as $functionName) {
             $filePath = '/tmp/'.$functionName.'.php';
-            static::assertFileExists($filePath);
+            self::assertFileExists($filePath);
             require_once $filePath;
-            static::assertTrue(\function_exists($functionName));
+            self::assertTrue(\function_exists($functionName));
         }
     }
 }


### PR DESCRIPTION
This also removes the `doctrine/annotations` dependency, as the serializer itself does not need it, and the `metadata-parser` has now a direct dependency on it anyway.

In addition to this, I also did the following:

* Update phpunit to 9.x
* Update PHPStan to 1.x
* Update php-cs-fixer to `3.17.0`
* Fix PHPStan issues
* Apply cs fixes
* Move PHPStan and php-cs-fixer check into separate github workflow (similar to what @dbu has done in https://github.com/liip/metadata-parser/pull/37)