### PR TITLE
improvement(DateTime): handle multiple deserialization formats and timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.6.0
+* (De)serialization now accepts timezones, and lists of deserialization formats
+
 # 2.5.1
 
 * Generalized the improvement on arrays with primitive types to generate more efficient code.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "liip/metadata-parser": "^1.1",
+        "liip/metadata-parser": "^1.2",
         "pnz/json-exception": "^1.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -212,12 +212,9 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                if (null !== $type->getZone()) {
-                    throw new \RuntimeException('Timezone support is not implemented');
-                }
-                $format = $type->getDeserializeFormat() ?: $type->getFormat();
+                $format = $type->getDeserializeFormats() ?: (is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $format) {
-                    return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $format);
+                    return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $format, $type->getZone());
                 }
 
                 return $this->templating->renderAssignDateTimeToField($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath);

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -212,7 +212,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                $format = $type->getDeserializeFormats() ?: (is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
+                $format = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $format) {
                     return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $format, $type->getZone());
                 }

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -213,9 +213,7 @@ final class DeserializerGenerator
 
             case $type instanceof PropertyTypeDateTime:
                 // todo: remove use of deprecated method {@link \Liip\MetadataParser\Metadata\PropertyTypeDateTime::getDeserializeFormat}
-                $formats = method_exists($type, 'getDeserializeFormats') ? $type->getDeserializeFormats() : null;
-                $singleFormat = $type->getDeserializeFormat() ?: $type->getFormat();
-                $formats = $formats ?: (\is_string($singleFormat) ? [$singleFormat] : $singleFormat);
+                $formats = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $formats) {
                     return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $formats, $type->getZone());
                 }

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -212,9 +212,12 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                $format = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
-                if (null !== $format) {
-                    return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $format, $type->getZone());
+                // todo: remove use of deprecated method {@link \Liip\MetadataParser\Metadata\PropertyTypeDateTime::getDeserializeFormat}
+                $formats = method_exists($type, 'getDeserializeFormats') ? $type->getDeserializeFormats() : null;
+                $singleFormat = $type->getDeserializeFormat() ?: $type->getFormat();
+                $formats = $formats ?: (\is_string($singleFormat) ? [$singleFormat] : $singleFormat);
+                if (null !== $formats) {
+                    return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $formats, $type->getZone());
                 }
 
                 return $this->templating->renderAssignDateTimeToField($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath);

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -205,7 +205,7 @@ final class DeserializerGenerator
 
         switch ($type) {
             case $type instanceof PropertyTypeArray:
-                if ($type->isCollection()) {
+                if ($type->isTraversable()) {
                     return $this->generateCodeForArrayCollection($propertyMetadata, $type, $arrayPath, $modelPropertyPath, $stack);
                 }
 

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -212,7 +212,6 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                // todo: remove use of deprecated method {@link \Liip\MetadataParser\Metadata\PropertyTypeDateTime::getDeserializeFormat}
                 $formats = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $formats) {
                     return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $formats, $type->getZone());

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -181,10 +181,7 @@ final class SerializerGenerator
     ): string {
         switch ($type) {
             case $type instanceof PropertyTypeDateTime:
-                if (null !== $type->getZone()) {
-                    throw new \RuntimeException('Timezone support is not implemented');
-                }
-                $dateFormat = $type->getFormat() ?: \DateTime::ISO8601;
+                $dateFormat = $type->getFormat() ?: \DateTimeInterface::ISO8601;
 
                 return $this->templating->renderAssign(
                     $fieldPath,

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -208,12 +208,12 @@ EOT;
         ]);
     }
 
-    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, ?string $timezone = null): string
+    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, string $timezone = null): string
     {
         $template = $immutable ? self::TMPL_ASSIGN_DATETIME_IMMUTABLE_FROM_FORMAT : self::TMPL_ASSIGN_DATETIME_FROM_FORMAT;
         $formatVariable = preg_replace_callback(
-            '/(^|[^a-zA-Z]+|\d+)([a-zA-Z])/',
-            fn($match) => (ctype_digit($match[1]) ? $match[1] : null).mb_strtoupper($match[2]),
+            '/([^a-zA-Z]+|\d+)([a-zA-Z])/',
+            static fn ($match) => (ctype_digit($match[1]) ? $match[1] : null).mb_strtoupper($match[2]),
             $modelPath
         );
 
@@ -222,9 +222,9 @@ EOT;
             'jsonPath' => $jsonPath,
             'formats' => array_map(
                 static fn (string $f) => var_export($f, true),
-                is_string($formats) ? [$formats] : $formats
+                \is_string($formats) ? [$formats] : $formats
             ),
-            'formatVariable' => '$'.$formatVariable,
+            'formatVariable' => '$'.lcfirst($formatVariable),
             'timezone' => $timezone ? 'new \DateTimeZone('.var_export($timezone, true).')' : 'null',
         ]);
     }

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -208,6 +208,9 @@ EOT;
         ]);
     }
 
+    /**
+     * @param list<string>|string $formats
+     */
     public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, string $timezone = null): string
     {
         $template = $immutable ? self::TMPL_ASSIGN_DATETIME_IMMUTABLE_FROM_FORMAT : self::TMPL_ASSIGN_DATETIME_FROM_FORMAT;

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -71,7 +71,7 @@ foreach([{{formats|join(', ')}}] as {{format}}) {
 }
 
 if (false === {{date}}) {
-    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats: '.({{formats|join('|')}}));
+    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats: '.{{formatsError}});
 }
 unset({{format}}, {{date}});
 
@@ -92,7 +92,7 @@ foreach([{{formats|join(', ')}}] as {{format}}) {
 }
 
 if (false === {{date}}) {
-    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats: '.({{formats|join('|')}}));
+    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats: '.{{formatsError}});
 }
 unset({{format}}, {{date}});
 
@@ -217,7 +217,7 @@ EOT;
      */
     public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, string $timezone = null): string
     {
-        if (is_string($formats)) {
+        if (\is_string($formats)) {
             @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', \E_USER_DEPRECATED);
             $formats = [$formats];
         }
@@ -227,16 +227,19 @@ EOT;
             static fn (string $f): string => var_export($f, true),
             $formats
         );
+        $formatsError = var_export(implode(',', $formats), true);
         $dateVariable = preg_replace_callback(
             '/([^a-zA-Z]+|\d+)([a-zA-Z])/',
             static fn ($match): string => (ctype_digit($match[1]) ? $match[1] : null).mb_strtoupper($match[2]),
             $modelPath
         );
 
+
         return $this->render($template, [
             'modelPath' => $modelPath,
             'jsonPath' => $jsonPath,
             'formats' => $formats,
+            'formatsError' => $formatsError,
             'format' => '$'.lcfirst($dateVariable).'Format',
             'date' => '$'.lcfirst($dateVariable),
             'timezone' => $timezone ? 'new \DateTimeZone('.var_export($timezone, true).')' : 'null',

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -234,7 +234,6 @@ EOT;
             $modelPath
         );
 
-
         return $this->render($template, [
             'modelPath' => $modelPath,
             'jsonPath' => $jsonPath,

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -62,7 +62,16 @@ EOT;
 EOT;
 
     private const TMPL_ASSIGN_DATETIME_FROM_FORMAT = <<<'EOT'
-{{modelPath}} = \DateTime::createFromFormat('{{format}}', {{jsonPath}});
+foreach([{{formats|join(', ')}}] as {{formatVariable}}) {
+    if (({{formatVariable}} = \DateTime::createFromFormat({{formatVariable}}, {{jsonPath}}, {{timezone}}))) {
+        {{modelPath}} = {{formatVariable}};
+        break;
+    }
+}
+
+if (false === ({{formatVariable}} ?? null)) {
+    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats '.({{formats|join('|')}}));
+}
 
 EOT;
 
@@ -72,7 +81,16 @@ EOT;
 EOT;
 
     private const TMPL_ASSIGN_DATETIME_IMMUTABLE_FROM_FORMAT = <<<'EOT'
-{{modelPath}} = \DateTimeImmutable::createFromFormat('{{format}}', {{jsonPath}});
+foreach([{{formats|join(', ')}}] as {{formatVariable}}) {
+    if (({{formatVariable}} = \DateTimeImmutable::createFromFormat({{formatVariable}}, {{jsonPath}}, {{timezone}}))) {
+        {{modelPath}} = {{formatVariable}};
+        break;
+    }
+}
+
+if (false === ({{formatVariable}} ?? null)) {
+    throw new \Exception('Invalid datetime string '.({{jsonPath}}).' matches none of the deserialization formats '.({{formats|join('|')}}));
+}
 
 EOT;
 
@@ -190,14 +208,24 @@ EOT;
         ]);
     }
 
-    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, string $format): string
+    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, ?string $timezone = null): string
     {
         $template = $immutable ? self::TMPL_ASSIGN_DATETIME_IMMUTABLE_FROM_FORMAT : self::TMPL_ASSIGN_DATETIME_FROM_FORMAT;
+        $formatVariable = preg_replace_callback(
+            '/(^|[^a-zA-Z]+|\d+)([a-zA-Z])/',
+            fn($match) => (ctype_digit($match[1]) ? $match[1] : null).mb_strtoupper($match[2]),
+            $modelPath
+        );
 
         return $this->render($template, [
             'modelPath' => $modelPath,
             'jsonPath' => $jsonPath,
-            'format' => $format,
+            'formats' => array_map(
+                static fn (string $f) => var_export($f, true),
+                is_string($formats) ? [$formats] : $formats
+            ),
+            'formatVariable' => '$'.$formatVariable,
+            'timezone' => $timezone ? 'new \DateTimeZone('.var_export($timezone, true).')' : 'null',
         ]);
     }
 

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -46,6 +46,27 @@ class Model
     public $dateWithFormat;
 
     /**
+     * @Serializer\Type("DateTime<'Y-m-d', '', 'd/m/Y'>")
+     *
+     * @var \DateTime
+     */
+    public $dateWithOneDeserializationFormat;
+
+    /**
+     * @Serializer\Type("DateTime<'Y-m-d', '', ['m/d/Y', 'Y-m-d']>")
+     *
+     * @var \DateTime
+     */
+    public $dateWithMultipleDeserializationFormats;
+
+    /**
+     * @Serializer\Type("DateTime<'Y-m-d', '+0600', '!d/m/Y'>")
+     *
+     * @var \DateTime
+     */
+    public $dateWithTimezone;
+
+    /**
      * @Serializer\Type("DateTimeImmutable")
      *
      * @var \DateTimeImmutable

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -52,6 +52,9 @@ class DeserializerGeneratorTest extends SerializerTestCase
             'nested_field' => ['nested_string' => 'nested'],
             'date' => '2018-08-03T00:00:00+02:00',
             'date_with_format' => '2018-08-04',
+            'date_with_one_deserialization_format' => '15/05/2019',
+            'date_with_multiple_deserialization_formats' => '05/16/2019',
+            'date_with_timezone' => '04/08/2018', // Defined timezone offset is +6 hours, so bringing it back to UTC removes a day
             'date_immutable' => '2016-06-01T00:00:00+02:00',
         ];
 
@@ -67,6 +70,12 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::assertSame('2018-08-03', $model->date->format('Y-m-d'));
         self::assertInstanceOf(\DateTime::class, $model->dateWithFormat);
         self::assertSame('2018-08-04', $model->dateWithFormat->format('Y-m-d'));
+        self::assertInstanceOf(\DateTime::class, $model->dateWithOneDeserializationFormat);
+        self::assertSame('2019-05-15', $model->dateWithOneDeserializationFormat->format('Y-m-d'));
+        self::assertInstanceOf(\DateTime::class, $model->dateWithMultipleDeserializationFormats);
+        self::assertSame('2019-05-16', $model->dateWithMultipleDeserializationFormats->format('Y-m-d'));
+        self::assertInstanceOf(\DateTime::class, $model->dateWithTimezone);
+        self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d'));
         self::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
         self::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
     }


### PR DESCRIPTION
The deserialization generator does not handle timezones for PropertyDateTime, and will throw an exception if the metadata contains any. In addition, with the https://github.com/liip/metadata-parser/pull/44 PR , I've also implemented the handling of multiple deserialization formats.

Here's a small script I've put together for this feature, from the same PR, just with the timezones added

```php
<?php

require_once 'vendor/autoload.php';

use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Collection;

use Doctrine\Common\Annotations\AnnotationReader;
use JMS\Serializer\Annotation as Serializer;
use Liip\MetadataParser\Builder;
use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
use Liip\MetadataParser\Parser;
use Liip\MetadataParser\RecursionChecker;
use Liip\MetadataParser\ModelParser\JMSParser;
use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
use Liip\MetadataParser\ModelParser\PhpDocParser;
use Liip\MetadataParser\ModelParser\ReflectionParser;
use Liip\MetadataParser\Reducer\TakeBestReducer;
use Liip\Serializer\Configuration\GeneratorConfiguration;


class Student {
    public ?string $name = null;

    /**
     * Simple case
     * @Serializer\Type("DateTimeImmutable<'Y-m-d'>")
     */
    public ?DateTimeImmutable $createdAt = null;
    /**
      * Type-hint doesn't match JMS type information (probably not the best practices, but works)
     * @Serializer\Type("DateTimeInterface<'Y-m-d'>")
     */
    public ?Datetime $updatedAt = null;
}

class Course
{
    public ?string $name = null;
    /**
     * @Serializer\Type("ArrayCollection<Student>")
     */
    public ?Collection $students = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * Timezone explicitly specified
      * @Serializer\Type("DateTime<'Y-m-d\TH:i:sP', 'UTC', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     public ?DateTimeInterface $startDate = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * Timezone explicitly specified
      * @Serializer\Type("DateTimeImmutable<'Y-m-d\TH:i:sP', 'UTC', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     public ?DateTimeInterface $endDate = null;

    public function __construct()
    {
        $this->students = new ArrayCollection();
    }
}

$parser = new Parser([
    new ReflectionParser(),
    new JMSParser(new AnnotationReader()),
    new PhpDocParser(),
    new LiipMetadataAnnotationParser(new AnnotationReader()),
]);

$builder = new Builder($parser, new RecursionChecker());
$classes = [Student::class, Course::class];
$configuration = GeneratorConfiguration::createFomArray([
    'classes' => array_fill_keys($classes, []),
]);

@mkdir($cacheDirectory = './cached/liip', 0777, true);
$deserializerGenerator = new \Liip\Serializer\DeserializerGenerator(new \Liip\Serializer\Template\Deserialization(), $classes, $cacheDirectory);
$deserializerGenerator->generate($builder);

$serializer = new \Liip\Serializer\Serializer($cacheDirectory);
var_dump($serializer->fromArray([
    'name' => 'Advanced php - II',
    'students' => [
        ['name' => 'Bob', 'created_at' => '2020-01-01', 'updated_at' => '2023-05-09'],
        ['name' => 'Alice', 'created_at' => '2021-02-12', 'updated_at' => '2023-05-09'],
    ],
    'startDate' => '2021-05-07T23:52:45+0000',
    'endDate' => '2023-06-15',
], Course::class));
```

~~P.S. : I'll be adding more tests later~~ More tests have been added for those cases