### PR TITLE
Loss of data for datetime fields if using a getter/setter

### DIFF
--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -232,7 +232,7 @@ EOT;
             '/([^a-zA-Z]+|\d+)([a-zA-Z])/',
             static fn ($match): string => (ctype_digit($match[1]) ? $match[1] : null).mb_strtoupper($match[2]),
             $modelPath
-        );
+        ).'Date';
 
         return $this->render($template, [
             'modelPath' => $modelPath,

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -77,17 +77,15 @@ class Model
      * @Serializer\Type("DateTimeImmutable")
      *
      * @Serializer\Accessor(getter="getDateImmutablePrivate", setter="setDateImmutablePrivate")
-     *
-     * @var \DateTimeImmutable|null
      */
     private $dateImmutablePrivate;
 
-    public function getDateImmutablePrivate(): ?\DateTimeInterface
+    public function getDateImmutablePrivate()
     {
         return $this->dateImmutablePrivate;
     }
 
-    public function setDateImmutablePrivate(?\DateTimeInterface $dateImmutablePrivate): void
+    public function setDateImmutablePrivate($dateImmutablePrivate): void
     {
         $this->dateImmutablePrivate = $dateImmutablePrivate;
     }

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -76,16 +76,18 @@ class Model
     /**
      * @Serializer\Type("DateTimeImmutable")
      *
-     * @var \DateTimeImmutable
+     * @Serializer\Accessor(getter="getDateImmutablePrivate", setter="setDateImmutablePrivate")
+     *
+     * @var \DateTimeImmutable|null
      */
     private $dateImmutablePrivate;
 
-    public function getDateImmutablePrivate(): \DateTimeImmutable
+    public function getDateImmutablePrivate(): ?\DateTimeInterface
     {
         return $this->dateImmutablePrivate;
     }
 
-    public function setDateImmutablePrivate(\DateTimeImmutable $dateImmutablePrivate): void
+    public function setDateImmutablePrivate(?\DateTimeInterface $dateImmutablePrivate): void
     {
         $this->dateImmutablePrivate = $dateImmutablePrivate;
     }

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -72,4 +72,21 @@ class Model
      * @var \DateTimeImmutable
      */
     public $dateImmutable;
+
+    /**
+     * @Serializer\Type("DateTimeImmutable")
+     *
+     * @var \DateTimeImmutable
+     */
+    private $dateImmutablePrivate;
+
+    public function getDateImmutablePrivate(): \DateTimeImmutable
+    {
+        return $this->dateImmutablePrivate;
+    }
+
+    public function setDateImmutablePrivate(\DateTimeImmutable $dateImmutablePrivate): void
+    {
+        $this->dateImmutablePrivate = $dateImmutablePrivate;
+    }
 }

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -56,6 +56,7 @@ class DeserializerGeneratorTest extends SerializerTestCase
             'date_with_multiple_deserialization_formats' => '05/16/2019',
             'date_with_timezone' => '04/08/2018', // Defined timezone offset is +6 hours, so bringing it back to UTC removes a day
             'date_immutable' => '2016-06-01T00:00:00+02:00',
+            'date_immutable_private' => '2016-06-01T00:00:00+02:00',
         ];
 
         /** @var Model $model */
@@ -78,6 +79,7 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d'));
         self::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
         self::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
+        self::assertSame('2016-06-01', $model->getDateImmutablePrivate()?->format('Y-m-d'));
     }
 
     public function testLists(): void


### PR DESCRIPTION
Following #39 , support for multiple datetime deserialization formats was added, but there is a bug where if the field requires a setter, the temporary variable made to hold the DateTime object has the same name as the temporary that will be passed to the setter.

I've used the same script as in that PR, and fixed the mistake where `start_date` and `end_date` of the test data array were written in camelCase instead of snake_case. The issue appears when the `Course::startDate` or `Course::endDate` fields are set to private instead of public. the `{{ date }}` variable is the same as the `{{ modelPath }}`, and is unset by the end of the section

```php
<?php

require_once 'vendor/autoload.php';

use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Collection;

use Doctrine\Common\Annotations\AnnotationReader;
use JMS\Serializer\Annotation as Serializer;
use Liip\MetadataParser\Builder;
use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
use Liip\MetadataParser\Parser;
use Liip\MetadataParser\RecursionChecker;
use Liip\MetadataParser\ModelParser\JMSParser;
use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
use Liip\MetadataParser\ModelParser\PhpDocParser;
use Liip\MetadataParser\ModelParser\ReflectionParser;
use Liip\MetadataParser\Reducer\TakeBestReducer;
use Liip\Serializer\Configuration\GeneratorConfiguration;

class IndirectAccess {
    private ?string $name = null;
    private ?string $parent = null;

    public function getName(): ?string {
        return $this->name;
    }

    public function setName(?string $name): void {
        $this->name = $name;
    }

    public function getParent(): ?string {
        return $this->parent;
    }

    public function setParent(?string $parent): void {
        $this->parent = $parent;
    }
}

class StudentDated {
    private ?string $name = null;

    /**
     * @Serializer\Type("DateTimeInterface<'Y-m-d\TH:i:sP', 'UTC'>")
     */
    private ?DateTimeImmutable $createdAt = null;
    /**
     * @Serializer\Type("DateTimeInterface<'Y-m-d\TH:i:sP', 'UTC'>")
     */
    private ?DateTime $updatedAt = null;
}

class Student {
    public ?string $name = null;

    /**
     * Simple case
     * @Serializer\Type("DateTimeImmutable<'Y-m-d'>")
     */
    public ?DateTimeImmutable $createdAt = null;
    /**
      * Type-hint doesn't match JMS type information (probably not the best practices, but works)
     * @Serializer\Type("DateTimeInterface<'Y-m-d'>")
     */
    public ?Datetime $updatedAt = null;
}

class Course
{
    public ?string $name = null;
    /**
     * @Serializer\Type("ArrayCollection<Student>")
     */
    public ?Collection $students = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * Timezone left for another PR
      * @Serializer\Type("DateTime<'Y-m-d\TH:i:sP', 'UTC', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     private ?DateTimeInterface $startDate = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * @Serializer\Type("DateTimeImmutable<'Y-m-d\TH:i:sP', 'UTC', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     private ?DateTimeInterface $endDate = null;

    public function __construct()
    {
        $this->students = new ArrayCollection();
    }

    public function getStartDate(): ?DateTimeInterface
    {
        return $this->startDate;
    }

    public function setStartDate(?DateTimeInterface $startDate): void
    {
        $this->startDate = $startDate;
    }

    public function getEndDate(): ?DateTimeInterface
    {
        return $this->endDate;
    }

    public function setEndDate(?DateTimeInterface $endDate): void
    {
        $this->endDate = $endDate;
    }
}

$parser = new Parser([
    new ReflectionParser(),
    new JMSParser(new AnnotationReader()),
    new PhpDocParser(),
    new LiipMetadataAnnotationParser(new AnnotationReader()),
    new VisibilityAwarePropertyAccessGuesser(),
]);

$builder = new Builder($parser, new RecursionChecker());
$metadata = $builder->build(IndirectAccess::class, [new TakeBestReducer()]);
//$classes = [IndirectAccess::class];
$classes = [Student::class, Course::class];
$configuration = GeneratorConfiguration::createFomArray([
    'classes' => array_fill_keys($classes, []),
]);

@mkdir('./cached');
@mkdir('./cached/liip');
$cacheDirectory = 'cached/liip';
$deserializerGenerator = new \Liip\Serializer\DeserializerGenerator(new \Liip\Serializer\Template\Deserialization(), $classes, $cacheDirectory);
$deserializerGenerator->generate($builder);

$serializer = new \Liip\Serializer\Serializer($cacheDirectory);
//$indirectAccessesData = [
//    ['name' => 'student', 'parent' => 'course'],
//];
//var_dump(array_map(
//    fn($data) => $serializer->fromArray($data, IndirectAccess::class), $indirectAccessesData
//));
var_dump($serializer->fromArray([
    'name' => 'Advanced php - II',
    'students' => [
        ['name' => 'Bob', 'created_at' => '2020-01-01', 'updated_at' => '2023-05-09'],
        ['name' => 'Alice', 'created_at' => '2021-02-12', 'updated_at' => '2023-05-09'],
    ],
    'start_date' => '2021-05-07T23:52:45+0000',
    'end_date' => '2023-06-15',
], Course::class));
```

_P.S.: First time I've made a PR with the tests first_ :partying_face: _but it's due to my own mistake_:disappointed: