### PR TITLE
Allow symfony 7 and also test against PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3']
         include:
           - php-version: '8.0'
             composer-flags: '--prefer-stable --prefer-lowest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed: Dates with a getter/setter where incorrectly handled in the refactoring for 2.6.0.
   See (#44)[https://github.com/liip/serializer/pull/44]
 * Add support for symfony `7.x`
+* Also test against PHP `8.3`
 
 # 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   See (#44)[https://github.com/liip/serializer/pull/44]
 * Add support for symfony `7.x`
 * Also test against PHP `8.3`
+* Update rector to `1.2.1`
 
 # 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed: Dates with a getter/setter where incorrectly handled in the refactoring for 2.6.0.
   See (#44)[https://github.com/liip/serializer/pull/44]
+* Add support for symfony `7.x`
 
 # 2.6.0
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "^0.19.0"
+        "rector/rector": "^1.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "ext-json": "*",
         "liip/metadata-parser": "^1.2",
         "pnz/json-exception": "^1.0",
-        "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
-        "symfony/finder": "^4.4 || ^5.0 || ^6.0",
-        "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "twig/twig": "^2.7 || ^3.0"
     },
     "require-dev": {

--- a/rector.php
+++ b/rector.php
@@ -9,13 +9,14 @@ use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\Class_\PropertyTypeFromStrictSetterGetterRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictBoolReturnExprRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictScalarReturnsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 
@@ -27,12 +28,13 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         InlineConstructorDefaultToPropertyRector::class,
-        ReturnTypeFromStrictBoolReturnExprRector::class,
+        BoolReturnTypeFromBooleanStrictReturnsRector::class,
         ReturnTypeFromStrictConstantReturnRector::class,
         ReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictNewArrayRector::class,
         ReturnTypeFromStrictParamRector::class,
-        ReturnTypeFromStrictScalarReturnExprRector::class,
+        NumericReturnTypeFromStrictScalarReturnsRector::class,
+        StringReturnTypeFromStrictScalarReturnsRector::class,
         PropertyTypeFromStrictSetterGetterRector::class,
         TypedPropertyFromStrictConstructorRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/tests/Fixtures/serialize_Tests_Liip_Serializer_Fixtures_SerializerModel.php
+++ b/tests/Fixtures/serialize_Tests_Liip_Serializer_Fixtures_SerializerModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-function serialize_Tests_Liip_Serializer_Fixtures_SerializerModel($model)
+function serialize_Tests_Liip_Serializer_Fixtures_SerializerModel($model): array
 {
     return ['all' => true];
 }

--- a/tests/Fixtures/serialize_Tests_Liip_Serializer_Fixtures_SerializerModel_api_2.php
+++ b/tests/Fixtures/serialize_Tests_Liip_Serializer_Fixtures_SerializerModel_api_2.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-function serialize_Tests_Liip_Serializer_Fixtures_SerializerModel_api_2($model)
+function serialize_Tests_Liip_Serializer_Fixtures_SerializerModel_api_2($model): array
 {
     return ['seen' => true];
 }


### PR DESCRIPTION
I made the following changes here:

* Allow symfony 7
   This version is already out for a while, so its probably a good idea to allow it as well. I'm not sure if it would make sense to drop support for symfony below `5.4` as those versions no longer receive any updates. Please let me know if I should update the version constraints here.
* Adjust the test matrix to also test against PHP `8.3`
* Update rector to the latest version
   A few rules were deprecated and had to be replaced with newer ones, but other than that, nothing much changed.


