### PR TITLE
Add (union) discriminator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 # 3.0.0 (unreleased)
 
+* Update to liip/metadata-parser 2.x
+* Add discriminator support
+
 # 2.x
 
 # 2.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 # 3.0.0 (unreleased)
 
 * Update to liip/metadata-parser 2.x
+  * The `LiipMetadataAnnotationParser` got renamed to `LiipMetadataAttributeParser` which means the `@Preferred` 
+    annotation is no longer allowed and has to be replaced by the `#[Preferred]` attribute.
+  * Setting a (different) naming strategy via the `PropertyCollection::useIdenticalNamingStrategy` is no longer 
+    possible, instead the naming strategy now has to be passed as the second argument when creating a new instance 
+    of the `Parser` class
+  * For further changes in this library, take a look at the 
+    [changelog from metadata-parser](https://github.com/liip/metadata-parser/blob/2.x/CHANGELOG.md)
 * Add discriminator support
 
 # 2.x

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Parser;
 use Liip\MetadataParser\RecursionChecker;
 use Liip\MetadataParser\ModelParser\JMSParser;
-use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
+use Liip\MetadataParser\ModelParser\LiipMetadataAttributeParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
 use Liip\Serializer\DeserializerGenerator;
@@ -75,7 +75,7 @@ $parsers = [
     new ReflectionParser(),
     new PhpDocParser(),
     new JMSParser(new AnnotationReader()),
-    new LiipMetadataAnnotationParser(new AnnotationReader()),
+    new LiipMetadataAttributeParser(),
 ];
 $builder = new Builder(new Parser($parsers), new RecursionChecker(null, []));
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "liip/metadata-parser": "^1.2",
+        "liip/metadata-parser": "^2.0",
         "pnz/json-exception": "^1.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6",
-        "friendsofphp/php-cs-fixer": "^3.23",
+        "friendsofphp/php-cs-fixer": "^3.90.0",
         "jms/serializer": "^1.13 || ^2 || ^3",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -7,7 +7,7 @@ namespace Liip\Serializer;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
-use Liip\MetadataParser\Metadata\PropertyTypeArray;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
@@ -204,7 +204,7 @@ final class DeserializerGenerator
         $type = $propertyMetadata->getType();
 
         switch ($type) {
-            case $type instanceof PropertyTypeArray:
+            case $type instanceof PropertyTypeIterable:
                 if ($type->isTraversable()) {
                     return $this->generateCodeForArrayCollection($propertyMetadata, $type, $arrayPath, $modelPropertyPath, $stack);
                 }
@@ -238,7 +238,7 @@ final class DeserializerGenerator
      * @param array<string, positive-int> $stack
      */
     private function generateCodeForArray(
-        PropertyTypeArray $type,
+        PropertyTypeIterable $type,
         ArrayPath $arrayPath,
         ModelPath $modelPath,
         array $stack,
@@ -254,7 +254,7 @@ final class DeserializerGenerator
         $subType = $type->getSubType();
 
         switch ($subType) {
-            case $subType instanceof PropertyTypeArray:
+            case $subType instanceof PropertyTypeIterable:
                 $innerCode = $this->generateCodeForArray($subType, $arrayPropertyPath, $modelPropertyPath, $stack);
                 break;
 
@@ -284,7 +284,7 @@ final class DeserializerGenerator
      */
     private function generateCodeForArrayCollection(
         PropertyMetadata $propertyMetadata,
-        PropertyTypeArray $type,
+        PropertyTypeIterable $type,
         ArrayPath $arrayPath,
         ModelPath $modelPath,
         array $stack,

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -8,10 +8,12 @@ use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
-use Liip\MetadataParser\Metadata\PropertyTypeIterable;
+use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
+use Liip\MetadataParser\Metadata\PropertyTypeUnion;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\Reducer\TakeBestReducer;
 use Liip\Serializer\Configuration\ClassToGenerate;
@@ -23,6 +25,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use function array_key_exists;
 use function count;
 use function is_string;
+use function sprintf;
 
 final class DeserializerGenerator
 {
@@ -159,15 +162,14 @@ final class DeserializerGenerator
         ClassMetadata $classMetadata,
         ArrayPath $arrayPath,
         ModelPath $modelPath,
-        array $stack = []
-    ): string
-    {
+        array $stack = [],
+    ): string {
         $code = '';
         $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
         $discriminatorFieldPath = $arrayPath->withFieldName($discriminatorMetadata->propertyName);
         foreach ($discriminatorMetadata->classMap as $typeValue => $class) {
             $code .= $this->templating->renderDiscriminatorConditional(
-                (string)$discriminatorFieldPath,
+                (string) $discriminatorFieldPath,
                 $typeValue,
                 $this->generateCodeForClass($discriminatorMetadata->getMetadataForClass($class), $arrayPath, $modelPath, $stack)
             );
@@ -262,9 +264,67 @@ final class DeserializerGenerator
             case $type instanceof PropertyTypeClass:
                 return $this->generateCodeForClass($type->getClassMetadata(), $arrayPath, $modelPropertyPath, $stack);
 
+            case $type instanceof PropertyTypeUnion:
+                return $this->generateCodeForUnion($type, $arrayPath, $modelPropertyPath, $stack);
+
             default:
                 throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
+    }
+
+    /**
+     * @param array<string, positive-int> $stack
+     */
+    private function generateCodeForUnion(
+        PropertyTypeUnion $type,
+        ArrayPath $arrayPath,
+        ModelPath $modelPath,
+        array $stack,
+    ): string {
+        $code = '';
+
+        $types = $type->getTypes();
+        $typesWithoutPrimitives = array_filter($types, static function (PropertyType $subType): bool {
+            return !($subType instanceof PropertyTypePrimitive || $subType instanceof PropertyTypeIterable);
+        });
+
+        $fieldName = $type->getFieldName();
+        if (null !== $fieldName) {
+            $discriminatorFieldPath = $arrayPath->withFieldName($fieldName);
+
+            foreach ($type->getTypeMap() as $typeValue => $class) {
+                $classType = $type->getTypeByClassName($class);
+                $code .= $this->templating->renderDiscriminatorConditional(
+                    (string) $discriminatorFieldPath,
+                    $typeValue,
+                    $this->generateCodeForClass($classType->getClassMetadata(), $arrayPath, $modelPath, $stack)
+                );
+            }
+
+            return $code;
+        }
+
+        if (0 !== count($typesWithoutPrimitives)) {
+            throw new Exception('Found union type that contains primitives and non primitives, which is currently not supported.');
+        }
+
+        $amountOfTypes = count($types);
+        foreach ($types as $key => $subType) {
+            $phpType = 'array';
+            if ($subType instanceof PropertyTypePrimitive) {
+                $phpType = $subType->getTypeName();
+            }
+
+            $withElseBlock = $key !== ($amountOfTypes - 1);
+            $code .= $this->templating->renderPrimitiveConditional(
+                $phpType,
+                (string) $arrayPath,
+                $this->templating->renderAssignJsonDataToFieldWithCast($phpType, (string) $modelPath, (string) $arrayPath),
+                $withElseBlock
+            );
+        }
+
+        return $code;
     }
 
     /**

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Liip\Serializer;
 
-use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
@@ -22,10 +21,6 @@ use Liip\Serializer\Path\ArrayPath;
 use Liip\Serializer\Path\ModelPath;
 use Liip\Serializer\Template\Deserialization;
 use Symfony\Component\Filesystem\Filesystem;
-use function array_key_exists;
-use function count;
-use function is_string;
-use function sprintf;
 
 final class DeserializerGenerator
 {
@@ -70,8 +65,8 @@ final class DeserializerGenerator
 
     private function writeFile(ClassMetadata $classMetadata): void
     {
-        if (count($classMetadata->getConstructorParameters())) {
-            throw new Exception(\sprintf('We currently do not support deserializing when the root class has a non-empty constructor. Class %s', $classMetadata->getClassName()));
+        if (\count($classMetadata->getConstructorParameters())) {
+            throw new \Exception(\sprintf('We currently do not support deserializing when the root class has a non-empty constructor. Class %s', $classMetadata->getClassName()));
         }
 
         $functionName = self::buildDeserializerFunctionName($classMetadata->getClassName());
@@ -114,7 +109,7 @@ final class DeserializerGenerator
                 $argument = $classMetadata->getConstructorParameter($propertyMetadata->getName());
                 $default = var_export($argument->isRequired() ? null : $argument->getDefaultValue(), true);
                 $tempVariable = ModelPath::tempVariable([(string) $modelPath, $propertyMetadata->getName()]);
-                if (array_key_exists($propertyMetadata->getName(), $constructorArgumentNames)) {
+                if (\array_key_exists($propertyMetadata->getName(), $constructorArgumentNames)) {
                     $overwrittenNames[$propertyMetadata->getName()] = true;
                 }
                 $constructorArgumentNames[$propertyMetadata->getName()] = (string) $tempVariable;
@@ -135,7 +130,7 @@ final class DeserializerGenerator
 
         $constructorArguments = [];
         foreach ($classMetadata->getConstructorParameters() as $definition) {
-            if (array_key_exists($definition->getName(), $constructorArgumentNames)) {
+            if (\array_key_exists($definition->getName(), $constructorArgumentNames)) {
                 $constructorArguments[] = $constructorArgumentNames[$definition->getName()];
                 continue;
             }
@@ -144,11 +139,11 @@ final class DeserializerGenerator
                 if ($overwrittenNames) {
                     $msg .= \sprintf(' Multiple definitions for fields %s seen - the last one overwrites previous ones.', implode(', ', array_keys($overwrittenNames)));
                 }
-                throw new Exception($msg);
+                throw new \Exception($msg);
             }
             $constructorArguments[] = var_export($definition->getDefaultValue(), true);
         }
-        if (count($constructorArgumentNames) > 0) {
+        if (\count($constructorArgumentNames) > 0) {
             $code .= $this->templating->renderUnset(array_values($constructorArgumentNames));
         }
 
@@ -247,7 +242,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                $formats = $type->getDeserializeFormats() ?: (is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
+                $formats = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $formats) {
                     return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $formats, $type->getZone());
                 }
@@ -268,7 +263,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForUnion($type, $arrayPath, $modelPropertyPath, $stack);
 
             default:
-                throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
+                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -304,11 +299,11 @@ final class DeserializerGenerator
             return $code;
         }
 
-        if (0 !== count($typesWithoutPrimitives)) {
-            throw new Exception('Found union type that contains primitives and non primitives, which is currently not supported.');
+        if (0 !== \count($typesWithoutPrimitives)) {
+            throw new \Exception('Found union type that contains primitives and non primitives, which is currently not supported.');
         }
 
-        $amountOfTypes = count($types);
+        $amountOfTypes = \count($types);
         foreach ($types as $key => $subType) {
             $phpType = 'array';
             if ($subType instanceof PropertyTypePrimitive) {
@@ -359,7 +354,7 @@ final class DeserializerGenerator
                 return $this->templating->renderAssignJsonDataToField((string) $modelPath, (string) $arrayPath);
 
             default:
-                throw new Exception('Unexpected array subtype '.$subType::class);
+                throw new \Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {

--- a/src/DeserializerGenerator.php
+++ b/src/DeserializerGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liip\Serializer;
 
+use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
@@ -19,6 +20,9 @@ use Liip\Serializer\Path\ArrayPath;
 use Liip\Serializer\Path\ModelPath;
 use Liip\Serializer\Template\Deserialization;
 use Symfony\Component\Filesystem\Filesystem;
+use function array_key_exists;
+use function count;
+use function is_string;
 
 final class DeserializerGenerator
 {
@@ -63,8 +67,8 @@ final class DeserializerGenerator
 
     private function writeFile(ClassMetadata $classMetadata): void
     {
-        if (\count($classMetadata->getConstructorParameters())) {
-            throw new \Exception(\sprintf('We currently do not support deserializing when the root class has a non-empty constructor. Class %s', $classMetadata->getClassName()));
+        if (count($classMetadata->getConstructorParameters())) {
+            throw new Exception(\sprintf('We currently do not support deserializing when the root class has a non-empty constructor. Class %s', $classMetadata->getClassName()));
         }
 
         $functionName = self::buildDeserializerFunctionName($classMetadata->getClassName());
@@ -89,6 +93,11 @@ final class DeserializerGenerator
         ModelPath $modelPath,
         array $stack = [],
     ): string {
+        $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
+        if (null !== $discriminatorMetadata && $discriminatorMetadata->baseClass == $classMetadata->getClassName()) {
+            return $this->generateCodeForDiscriminatorClass($classMetadata, $arrayPath, $modelPath, $stack);
+        }
+
         $stack[$classMetadata->getClassName()] = ($stack[$classMetadata->getClassName()] ?? 0) + 1;
 
         $constructorArgumentNames = [];
@@ -102,7 +111,7 @@ final class DeserializerGenerator
                 $argument = $classMetadata->getConstructorParameter($propertyMetadata->getName());
                 $default = var_export($argument->isRequired() ? null : $argument->getDefaultValue(), true);
                 $tempVariable = ModelPath::tempVariable([(string) $modelPath, $propertyMetadata->getName()]);
-                if (\array_key_exists($propertyMetadata->getName(), $constructorArgumentNames)) {
+                if (array_key_exists($propertyMetadata->getName(), $constructorArgumentNames)) {
                     $overwrittenNames[$propertyMetadata->getName()] = true;
                 }
                 $constructorArgumentNames[$propertyMetadata->getName()] = (string) $tempVariable;
@@ -123,7 +132,7 @@ final class DeserializerGenerator
 
         $constructorArguments = [];
         foreach ($classMetadata->getConstructorParameters() as $definition) {
-            if (\array_key_exists($definition->getName(), $constructorArgumentNames)) {
+            if (array_key_exists($definition->getName(), $constructorArgumentNames)) {
                 $constructorArguments[] = $constructorArgumentNames[$definition->getName()];
                 continue;
             }
@@ -132,15 +141,39 @@ final class DeserializerGenerator
                 if ($overwrittenNames) {
                     $msg .= \sprintf(' Multiple definitions for fields %s seen - the last one overwrites previous ones.', implode(', ', array_keys($overwrittenNames)));
                 }
-                throw new \Exception($msg);
+                throw new Exception($msg);
             }
             $constructorArguments[] = var_export($definition->getDefaultValue(), true);
         }
-        if (\count($constructorArgumentNames) > 0) {
+        if (count($constructorArgumentNames) > 0) {
             $code .= $this->templating->renderUnset(array_values($constructorArgumentNames));
         }
 
         return $this->templating->renderClass((string) $modelPath, $classMetadata->getClassName(), $constructorArguments, $code, $initCode);
+    }
+
+    /**
+     * @param array<string, positive-int> $stack
+     */
+    private function generateCodeForDiscriminatorClass(
+        ClassMetadata $classMetadata,
+        ArrayPath $arrayPath,
+        ModelPath $modelPath,
+        array $stack = []
+    ): string
+    {
+        $code = '';
+        $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
+        $discriminatorFieldPath = $arrayPath->withFieldName($discriminatorMetadata->propertyName);
+        foreach ($discriminatorMetadata->classMap as $typeValue => $class) {
+            $code .= $this->templating->renderDiscriminatorConditional(
+                (string)$discriminatorFieldPath,
+                $typeValue,
+                $this->generateCodeForClass($discriminatorMetadata->getMetadataForClass($class), $arrayPath, $modelPath, $stack)
+            );
+        }
+
+        return $code;
     }
 
     /**
@@ -212,7 +245,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForArray($type, $arrayPath, $modelPropertyPath, $stack);
 
             case $type instanceof PropertyTypeDateTime:
-                $formats = $type->getDeserializeFormats() ?: (\is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
+                $formats = $type->getDeserializeFormats() ?: (is_string($type->getFormat()) ? [$type->getFormat()] : $type->getFormat());
                 if (null !== $formats) {
                     return $this->templating->renderAssignDateTimeFromFormat($type->isImmutable(), (string) $modelPropertyPath, (string) $arrayPath, $formats, $type->getZone());
                 }
@@ -230,7 +263,7 @@ final class DeserializerGenerator
                 return $this->generateCodeForClass($type->getClassMetadata(), $arrayPath, $modelPropertyPath, $stack);
 
             default:
-                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
+                throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -266,7 +299,7 @@ final class DeserializerGenerator
                 return $this->templating->renderAssignJsonDataToField((string) $modelPath, (string) $arrayPath);
 
             default:
-                throw new \Exception('Unexpected array subtype '.$subType::class);
+                throw new Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {

--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Liip\Serializer;
 
 use Liip\MetadataParser\Metadata\PropertyMetadata;
-use Liip\MetadataParser\Metadata\PropertyTypeArray;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 
 abstract class Recursion
@@ -44,7 +44,7 @@ abstract class Recursion
     private static function getClassNameFromProperty(PropertyMetadata $propertyMetadata): ?string
     {
         $type = $propertyMetadata->getType();
-        if ($type instanceof PropertyTypeArray) {
+        if ($type instanceof PropertyTypeIterable) {
             $type = $type->getLeafType();
         }
 

--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Liip\Serializer;
 
 use Liip\MetadataParser\Metadata\PropertyMetadata;
-use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 
 abstract class Recursion
 {

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -8,9 +8,9 @@ use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
 use Liip\MetadataParser\Metadata\PropertyType;
-use Liip\MetadataParser\Metadata\PropertyTypeArray;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\Reducer\GroupReducer;
@@ -196,7 +196,7 @@ final class SerializerGenerator
             case $type instanceof PropertyTypeClass:
                 return $this->generateCodeForClass($type->getClassMetadata(), $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
-            case $type instanceof PropertyTypeArray:
+            case $type instanceof PropertyTypeIterable:
                 return $this->generateCodeForArray($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
             default:
@@ -209,7 +209,7 @@ final class SerializerGenerator
      * @param array<string, positive-int> $stack
      */
     private function generateCodeForArray(
-        PropertyTypeArray $type,
+        PropertyTypeIterable $type,
         ?string $apiVersion,
         array $serializerGroups,
         string $arrayPath,
@@ -221,11 +221,11 @@ final class SerializerGenerator
 
         switch ($subType) {
             case $subType instanceof PropertyTypePrimitive:
-            case $subType instanceof PropertyTypeArray && self::isArrayForPrimitive($subType):
+            case $subType instanceof PropertyTypeIterable && self::isArrayForPrimitive($subType):
             case $subType instanceof PropertyTypeUnknown && $this->configuration->shouldAllowGenericArrays():
                 return $this->templating->renderArrayAssign($arrayPath, $modelPath);
 
-            case $subType instanceof PropertyTypeArray:
+            case $subType instanceof PropertyTypeIterable:
                 $innerCode = $this->generateCodeForArray($subType, $apiVersion, $serializerGroups, $arrayPath.'['.$index.']', $modelPath.'['.$index.']', $stack);
                 break;
 
@@ -252,14 +252,14 @@ final class SerializerGenerator
         return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode);
     }
 
-    private static function isArrayForPrimitive(PropertyTypeArray $type): bool
+    private static function isArrayForPrimitive(PropertyTypeIterable $type): bool
     {
         do {
             $type = $type->getSubType();
             if ($type instanceof PropertyTypePrimitive) {
                 return true;
             }
-        } while ($type instanceof PropertyTypeArray);
+        } while ($type instanceof PropertyTypeIterable);
 
         return false;
     }

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Liip\Serializer;
 
+use DateTimeInterface;
+use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
@@ -20,6 +22,7 @@ use Liip\MetadataParser\Reducer\VersionReducer;
 use Liip\Serializer\Configuration\GeneratorConfiguration;
 use Liip\Serializer\Template\Serialization;
 use Symfony\Component\Filesystem\Filesystem;
+use function count;
 
 final class SerializerGenerator
 {
@@ -41,7 +44,7 @@ final class SerializerGenerator
     public static function buildSerializerFunctionName(string $className, ?string $apiVersion, array $serializerGroups): string
     {
         $functionName = self::FILENAME_PREFIX.'_'.$className;
-        if (\count($serializerGroups)) {
+        if (count($serializerGroups)) {
             $functionName .= '_'.implode('_', $serializerGroups);
         }
         if (null !== $apiVersion) {
@@ -120,6 +123,11 @@ final class SerializerGenerator
         string $modelPath,
         array $stack = [],
     ): string {
+        $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
+        if (null !== $discriminatorMetadata && $discriminatorMetadata->baseClass == $classMetadata->getClassName()) {
+            return $this->generateCodeForDiscriminatorClass($classMetadata, $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack);
+        }
+
         $stack[$classMetadata->getClassName()] = ($stack[$classMetadata->getClassName()] ?? 0) + 1;
 
         $code = '';
@@ -127,7 +135,37 @@ final class SerializerGenerator
             $code .= $this->generateCodeForField($propertyMetadata, $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack);
         }
 
+        if (null !== $discriminatorMetadata)  {
+            $discriminatorFieldPath = $arrayPath.'["'.$discriminatorMetadata->propertyName.'"]';
+            $code .= $this->templating->renderAssign($discriminatorFieldPath, sprintf("'%s'", $discriminatorMetadata->value));
+        }
+
         return $this->templating->renderClass($arrayPath, $code);
+    }
+
+    /**
+     * @param list<string>                $serializerGroups
+     * @param array<string, positive-int> $stack
+     */
+    private function generateCodeForDiscriminatorClass(
+        ClassMetadata $classMetadata,
+        ?string $apiVersion,
+        array $serializerGroups,
+        string $arrayPath,
+        string $modelPath,
+        array $stack = []
+    ): string {
+        $code = '';
+        $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
+        foreach ($discriminatorMetadata->classMap as $class) {
+            $code .= $this->templating->renderInstanceOfConditional(
+                $modelPath,
+                $class,
+                $this->generateCodeForClass($discriminatorMetadata->getMetadataForClass($class), $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack)
+            );
+        }
+
+        return $code;
     }
 
     /**
@@ -158,7 +196,7 @@ final class SerializerGenerator
             );
         }
         if (!$propertyMetadata->isPublic()) {
-            throw new \Exception(\sprintf('Property %s is not public and no getter has been defined. Stack %s', $modelPropertyPath, var_export($stack, true)));
+            throw new Exception(\sprintf('Property %s is not public and no getter has been defined. Stack %s', $modelPropertyPath, var_export($stack, true)));
         }
 
         return $this->templating->renderConditional(
@@ -181,7 +219,7 @@ final class SerializerGenerator
     ): string {
         switch ($type) {
             case $type instanceof PropertyTypeDateTime:
-                $dateFormat = $type->getFormat() ?: \DateTimeInterface::ISO8601;
+                $dateFormat = $type->getFormat() ?: DateTimeInterface::ISO8601;
 
                 return $this->templating->renderAssign(
                     $fieldPath,
@@ -200,7 +238,7 @@ final class SerializerGenerator
                 return $this->generateCodeForArray($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
             default:
-                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
+                throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -234,7 +272,7 @@ final class SerializerGenerator
                 break;
 
             default:
-                throw new \Exception('Unexpected array subtype '.$subType::class);
+                throw new Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -14,6 +14,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
+use Liip\MetadataParser\Metadata\PropertyTypeUnion;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\Reducer\GroupReducer;
 use Liip\MetadataParser\Reducer\PreferredReducer;
@@ -23,6 +24,7 @@ use Liip\Serializer\Configuration\GeneratorConfiguration;
 use Liip\Serializer\Template\Serialization;
 use Symfony\Component\Filesystem\Filesystem;
 use function count;
+use function sprintf;
 
 final class SerializerGenerator
 {
@@ -135,7 +137,7 @@ final class SerializerGenerator
             $code .= $this->generateCodeForField($propertyMetadata, $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack);
         }
 
-        if (null !== $discriminatorMetadata)  {
+        if (null !== $discriminatorMetadata) {
             $discriminatorFieldPath = $arrayPath.'["'.$discriminatorMetadata->propertyName.'"]';
             $code .= $this->templating->renderAssign($discriminatorFieldPath, sprintf("'%s'", $discriminatorMetadata->value));
         }
@@ -153,7 +155,7 @@ final class SerializerGenerator
         array $serializerGroups,
         string $arrayPath,
         string $modelPath,
-        array $stack = []
+        array $stack = [],
     ): string {
         $code = '';
         $discriminatorMetadata = $classMetadata->getDiscriminatorMetadata();
@@ -237,6 +239,9 @@ final class SerializerGenerator
             case $type instanceof PropertyTypeIterable:
                 return $this->generateCodeForArray($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
+            case $type instanceof PropertyTypeUnion:
+                return $this->generateCodeForUnion($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
+
             default:
                 throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
@@ -288,6 +293,54 @@ final class SerializerGenerator
         }
 
         return $this->templating->renderLoopArray($arrayPath, $modelPath, $index, $innerCode);
+    }
+
+    /**
+     * @param list<string>                $serializerGroups
+     * @param array<string, positive-int> $stack
+     */
+    private function generateCodeForUnion(
+        PropertyTypeUnion $subType,
+        ?string $apiVersion,
+        array $serializerGroups,
+        string $arrayPath,
+        string $modelPath,
+        array $stack,
+    ): string {
+        $code = '';
+
+        $types = $subType->getTypes();
+        $typesWithoutPrimitives = array_filter($types, static function (PropertyType $subType): bool {
+            return !($subType instanceof PropertyTypePrimitive || $subType instanceof PropertyTypeUnknown);
+        });
+
+        $hasPrimitives = count($types) !== count($typesWithoutPrimitives);
+        if ($hasPrimitives) {
+            $code .= $this->templating->renderPrimitiveConditional(
+                $modelPath,
+                $this->templating->renderAssign($arrayPath, $modelPath)
+            );
+        }
+
+        foreach ($typesWithoutPrimitives as $subType) {
+            switch ($subType::class) {
+                case PropertyTypeClass::class:
+                    $code .= $this->templating->renderInstanceOfConditional(
+                        $modelPath,
+                        $subType->getClassName(),
+                        $this->generateCodeForFieldType($subType, $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack)
+                    );
+                    break;
+                case PropertyTypeIterable::class:
+                    $code .= $this->templating->renderArrayConditional(
+                        $modelPath,
+                        $this->generateCodeForArray($subType, $apiVersion, $serializerGroups, $arrayPath, $modelPath, $stack)
+                    );
+                    break;
+            }
+        }
+
+        return $code;
     }
 
     private static function isArrayForPrimitive(PropertyTypeIterable $type): bool

--- a/src/SerializerGenerator.php
+++ b/src/SerializerGenerator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Liip\Serializer;
 
-use DateTimeInterface;
-use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\ClassMetadata;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
@@ -23,8 +21,6 @@ use Liip\MetadataParser\Reducer\VersionReducer;
 use Liip\Serializer\Configuration\GeneratorConfiguration;
 use Liip\Serializer\Template\Serialization;
 use Symfony\Component\Filesystem\Filesystem;
-use function count;
-use function sprintf;
 
 final class SerializerGenerator
 {
@@ -46,7 +42,7 @@ final class SerializerGenerator
     public static function buildSerializerFunctionName(string $className, ?string $apiVersion, array $serializerGroups): string
     {
         $functionName = self::FILENAME_PREFIX.'_'.$className;
-        if (count($serializerGroups)) {
+        if (\count($serializerGroups)) {
             $functionName .= '_'.implode('_', $serializerGroups);
         }
         if (null !== $apiVersion) {
@@ -139,7 +135,7 @@ final class SerializerGenerator
 
         if (null !== $discriminatorMetadata) {
             $discriminatorFieldPath = $arrayPath.'["'.$discriminatorMetadata->propertyName.'"]';
-            $code .= $this->templating->renderAssign($discriminatorFieldPath, sprintf("'%s'", $discriminatorMetadata->value));
+            $code .= $this->templating->renderAssign($discriminatorFieldPath, \sprintf("'%s'", $discriminatorMetadata->value));
         }
 
         return $this->templating->renderClass($arrayPath, $code);
@@ -198,7 +194,7 @@ final class SerializerGenerator
             );
         }
         if (!$propertyMetadata->isPublic()) {
-            throw new Exception(\sprintf('Property %s is not public and no getter has been defined. Stack %s', $modelPropertyPath, var_export($stack, true)));
+            throw new \Exception(\sprintf('Property %s is not public and no getter has been defined. Stack %s', $modelPropertyPath, var_export($stack, true)));
         }
 
         return $this->templating->renderConditional(
@@ -221,7 +217,7 @@ final class SerializerGenerator
     ): string {
         switch ($type) {
             case $type instanceof PropertyTypeDateTime:
-                $dateFormat = $type->getFormat() ?: DateTimeInterface::ISO8601;
+                $dateFormat = $type->getFormat() ?: \DateTimeInterface::ISO8601;
 
                 return $this->templating->renderAssign(
                     $fieldPath,
@@ -243,7 +239,7 @@ final class SerializerGenerator
                 return $this->generateCodeForUnion($type, $apiVersion, $serializerGroups, $fieldPath, $modelPropertyPath, $stack);
 
             default:
-                throw new Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
+                throw new \Exception('Unexpected type '.$type::class.' at '.$modelPropertyPath);
         }
     }
 
@@ -277,7 +273,7 @@ final class SerializerGenerator
                 break;
 
             default:
-                throw new Exception('Unexpected array subtype '.$subType::class);
+                throw new \Exception('Unexpected array subtype '.$subType::class);
         }
 
         if ('' === $innerCode) {
@@ -314,7 +310,7 @@ final class SerializerGenerator
             return !($subType instanceof PropertyTypePrimitive || $subType instanceof PropertyTypeUnknown);
         });
 
-        $hasPrimitives = count($types) !== count($typesWithoutPrimitives);
+        $hasPrimitives = \count($types) !== \count($typesWithoutPrimitives);
         if ($hasPrimitives) {
             $code .= $this->templating->renderPrimitiveConditional(
                 $modelPath,

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -6,6 +6,8 @@ namespace Liip\Serializer\Template;
 
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use function is_string;
+use const E_USER_DEPRECATED;
 
 final class Deserialization
 {
@@ -41,6 +43,13 @@ EOT;
 
     private const TMPL_CONDITIONAL = <<<'EOT'
 if (isset({{data}})) {
+    {{code}}
+}
+
+EOT;
+
+    private const TMPL_DISCRIMINATOR_CONDITIONAL = <<<'EOT'
+if ({{jsonPath}} === '{{typeValue}}') {
     {{code}}
 }
 
@@ -185,6 +194,15 @@ EOT;
         ]);
     }
 
+    public function renderDiscriminatorConditional(string $jsonPath, string $typeValue, string $code): string
+    {
+        return $this->render(self::TMPL_DISCRIMINATOR_CONDITIONAL, [
+            'jsonPath' => $jsonPath,
+            'typeValue' => $typeValue,
+            'code' => $code,
+        ]);
+    }
+
     public function renderAssignJsonDataToField(string $modelPath, string $jsonPath): string
     {
         return $this->render(self::TMPL_ASSIGN_JSON_DATA_TO_FIELD, [
@@ -217,8 +235,8 @@ EOT;
      */
     public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, ?string $timezone = null): string
     {
-        if (\is_string($formats)) {
-            @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', \E_USER_DEPRECATED);
+        if (is_string($formats)) {
+            @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', E_USER_DEPRECATED);
             $formats = [$formats];
         }
 

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -4,13 +4,34 @@ declare(strict_types=1);
 
 namespace Liip\Serializer\Template;
 
+use InvalidArgumentException;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use function is_string;
+use function sprintf;
 use const E_USER_DEPRECATED;
 
 final class Deserialization
 {
+    private const PRIMITIVE_CHECKS = [
+        'null' => 'is_null({{value}})',
+        'array' => 'is_array({{value}})',
+        'int' => '(string) (int) {{value}} === (string) {{value}}',
+        'float' => '(string) (float) {{value}} === (string) {{value}}',
+        'bool' => '!is_array({{value}}) && (string) (bool) {{value}} === (string) {{value}}',
+        'true' => 'true === {{value}}',
+        'false' => 'false === {{value}}',
+        'string' => '!is_array({{value}}) && !is_object({{value}})',
+    ];
+
+    private const PRIMITIVE_CASTS = [
+        'array' => '{{value}}',
+        'int' => '(int) {{value}}',
+        'float' => '(float) {{value}}',
+        'bool' => '(bool) {{value}}',
+        'string' => '(string) {{value}}',
+    ];
+
     private const TMPL_FUNCTION = <<<'EOT'
 <?php
 
@@ -52,6 +73,13 @@ EOT;
 if ({{jsonPath}} === '{{typeValue}}') {
     {{code}}
 }
+
+EOT;
+
+    private const TMPL_PRIMITIVE_CONDITIONAL = <<<'EOT'
+if ({{typeConditional}}) {
+    {{code}}
+} {% if withElseBlock %} else {% endif %}
 
 EOT;
 
@@ -203,8 +231,41 @@ EOT;
         ]);
     }
 
+    public function renderPrimitiveConditional(string $phpType, string $jsonPath, string $code, bool $withElseBlock = false): string
+    {
+        $typeCheck = self::PRIMITIVE_CHECKS[$phpType] ?? null;
+        if (null === $typeCheck) {
+            throw new InvalidArgumentException(sprintf('Provided type "%s" but only the following types are supported: %s', $phpType, implode(', ', array_keys(self::PRIMITIVE_CHECKS))));
+        }
+
+        $typeConditional = $this->render($typeCheck, [
+            'value' => $jsonPath,
+        ]);
+
+        return $this->render(self::TMPL_PRIMITIVE_CONDITIONAL, [
+            'typeConditional' => $typeConditional,
+            'code' => $code,
+            'withElseBlock' => $withElseBlock,
+        ]);
+    }
+
     public function renderAssignJsonDataToField(string $modelPath, string $jsonPath): string
     {
+        return $this->render(self::TMPL_ASSIGN_JSON_DATA_TO_FIELD, [
+            'modelPath' => $modelPath,
+            'jsonPath' => $jsonPath,
+        ]);
+    }
+
+    public function renderAssignJsonDataToFieldWithCast(string $phpType, string $modelPath, string $jsonPath): string
+    {
+        $typeCast = self::PRIMITIVE_CASTS[$phpType] ?? null;
+        if (null !== $typeCast) {
+            $jsonPath = $this->render($typeCast, [
+                'value' => $jsonPath,
+            ]);
+        }
+
         return $this->render(self::TMPL_ASSIGN_JSON_DATA_TO_FIELD, [
             'modelPath' => $modelPath,
             'jsonPath' => $jsonPath,

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -288,15 +288,10 @@ EOT;
     }
 
     /**
-     * @param list<string>|string $formats
+     * @param list<string> $formats
      */
-    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, ?string $timezone = null): string
+    public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array $formats, ?string $timezone = null): string
     {
-        if (\is_string($formats)) {
-            @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', \E_USER_DEPRECATED);
-            $formats = [$formats];
-        }
-
         $template = $immutable ? self::TMPL_ASSIGN_DATETIME_IMMUTABLE_FROM_FORMAT : self::TMPL_ASSIGN_DATETIME_FROM_FORMAT;
         $formats = array_map(
             static fn (string $f): string => var_export($f, true),

--- a/src/Template/Deserialization.php
+++ b/src/Template/Deserialization.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace Liip\Serializer\Template;
 
-use InvalidArgumentException;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use function is_string;
-use function sprintf;
-use const E_USER_DEPRECATED;
 
 final class Deserialization
 {
@@ -235,7 +231,7 @@ EOT;
     {
         $typeCheck = self::PRIMITIVE_CHECKS[$phpType] ?? null;
         if (null === $typeCheck) {
-            throw new InvalidArgumentException(sprintf('Provided type "%s" but only the following types are supported: %s', $phpType, implode(', ', array_keys(self::PRIMITIVE_CHECKS))));
+            throw new \InvalidArgumentException(\sprintf('Provided type "%s" but only the following types are supported: %s', $phpType, implode(', ', array_keys(self::PRIMITIVE_CHECKS))));
         }
 
         $typeConditional = $this->render($typeCheck, [
@@ -296,8 +292,8 @@ EOT;
      */
     public function renderAssignDateTimeFromFormat(bool $immutable, string $modelPath, string $jsonPath, array|string $formats, ?string $timezone = null): string
     {
-        if (is_string($formats)) {
-            @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', E_USER_DEPRECATED);
+        if (\is_string($formats)) {
+            @trigger_error('Passing a string for argument $formats is deprecated, please pass an array of strings instead', \E_USER_DEPRECATED);
             $formats = [$formats];
         }
 

--- a/src/Template/Serialization.php
+++ b/src/Template/Serialization.php
@@ -40,6 +40,13 @@ if (null !== {{condition}}) {
 
 EOT;
 
+    private const TMPL_INSTANCE_OF_CONDITIONAL = <<<'EOT'
+if ({{propertyAccessor}} instanceof {{class}}) {
+    {{code}}
+}
+
+EOT;
+
     private const TMPL_ASSIGN = <<<'EOT'
 $jsonData{{jsonPath}} = {{propertyAccessor}};
 EOT;
@@ -120,6 +127,15 @@ EOT;
     {
         return $this->render(self::TMPL_CONDITIONAL, [
             'condition' => $condition,
+            'code' => $code,
+        ]);
+    }
+
+    public function renderInstanceOfConditional(string $propertyAccessor, string $class, string $code): string
+    {
+        return $this->render(self::TMPL_INSTANCE_OF_CONDITIONAL, [
+            'propertyAccessor' => $propertyAccessor,
+            'class' => $class,
             'code' => $code,
         ]);
     }

--- a/src/Template/Serialization.php
+++ b/src/Template/Serialization.php
@@ -16,6 +16,14 @@ function {{functionName}}({{className}} $model, bool $useStdClass = true)
 {
     $emptyHashmap = $useStdClass ? new \stdClass() : [];
     $emptyObject = $useStdClass ? new \stdClass() : [];
+    $isPrimitive = function (mixed $data) {
+        if (is_array($data)) {
+            return false;
+        }
+    
+        return null === $data || is_scalar($data);
+    };
+    
 
     {{code}}
 
@@ -45,6 +53,18 @@ if ({{propertyAccessor}} instanceof {{class}}) {
     {{code}}
 }
 
+EOT;
+
+    private const TMPL_PRIMITIVE_CONDITIONAL = <<<'EOT'
+if ($isPrimitive({{propertyAccessor}})) {
+    {{code}}
+}
+EOT;
+
+    private const TMPL_ARRAY_CONDITIONAL = <<<'EOT'
+if (is_array({{propertyAccessor}})) {
+    {{code}}
+}
 EOT;
 
     private const TMPL_ASSIGN = <<<'EOT'
@@ -136,6 +156,22 @@ EOT;
         return $this->render(self::TMPL_INSTANCE_OF_CONDITIONAL, [
             'propertyAccessor' => $propertyAccessor,
             'class' => $class,
+            'code' => $code,
+        ]);
+    }
+
+    public function renderPrimitiveConditional(string $propertyAccessor, string $code): string
+    {
+        return $this->render(self::TMPL_PRIMITIVE_CONDITIONAL, [
+            'propertyAccessor' => $propertyAccessor,
+            'code' => $code,
+        ]);
+    }
+
+    public function renderArrayConditional(string $propertyAccessor, string $code): string
+    {
+        return $this->render(self::TMPL_ARRAY_CONDITIONAL, [
+            'propertyAccessor' => $propertyAccessor,
             'code' => $code,
         ]);
     }

--- a/tests/Fixtures/ComplexUnionTyping.php
+++ b/tests/Fixtures/ComplexUnionTyping.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation\UnionDiscriminator;
+
+class ComplexUnionTyping
+{
+    #[UnionDiscriminator(field: 'objectType', map: ['comment' => DiscriminatorComment::class, 'author' => DiscriminatorAuthor::class])]
+    public DiscriminatorComment|DiscriminatorAuthor $property;
+}

--- a/tests/Fixtures/Discriminator.php
+++ b/tests/Fixtures/Discriminator.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\Discriminator(field = "type", map = {
+ *     "first": "Tests\Liip\Serializer\Fixtures\DiscriminatorFirstChild",
+ *     "second": "Tests\Liip\Serializer\Fixtures\DiscriminatorSecondChild"
+ * })
+ */
+abstract class Discriminator
+{
+}

--- a/tests/Fixtures/DiscriminatorAuthor.php
+++ b/tests/Fixtures/DiscriminatorAuthor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+
+class DiscriminatorAuthor
+{
+    public string $name;
+
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'objectType')]
+    public $objectType = 'author';
+}

--- a/tests/Fixtures/DiscriminatorComment.php
+++ b/tests/Fixtures/DiscriminatorComment.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+
+class DiscriminatorComment
+{
+    public string $text;
+
+    #[Type(name: 'string')]
+    #[SerializedName(name: 'objectType')]
+    public $objectType = 'comment';
+
+    public function getObjectType(): string
+    {
+        return $this->objectType;
+    }
+}

--- a/tests/Fixtures/DiscriminatorDependency.php
+++ b/tests/Fixtures/DiscriminatorDependency.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+class DiscriminatorDependency
+{
+    public Discriminator $discriminator;
+}

--- a/tests/Fixtures/DiscriminatorFirstChild.php
+++ b/tests/Fixtures/DiscriminatorFirstChild.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+class DiscriminatorFirstChild extends Discriminator
+{
+    public string $firstProperty;
+}

--- a/tests/Fixtures/DiscriminatorSecondChild.php
+++ b/tests/Fixtures/DiscriminatorSecondChild.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+class DiscriminatorSecondChild extends Discriminator
+{
+    public string $secondProperty;
+}

--- a/tests/Fixtures/PrimitiveUnionTyping.php
+++ b/tests/Fixtures/PrimitiveUnionTyping.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Fixtures;
+
+class PrimitiveUnionTyping
+{
+    public int|string|false|float|array|null $property;
+}

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Liip\Serializer\Unit;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Collections\ArrayCollection;
 use Liip\MetadataParser\Builder;
@@ -13,6 +16,9 @@ use Liip\MetadataParser\ModelParser\ReflectionParser;
 use Liip\Serializer\DeserializerGenerator;
 use Liip\Serializer\Template\Deserialization;
 use Tests\Liip\Serializer\Fixtures\ContainsNonEmptyConstructor;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorDependency;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorFirstChild;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorSecondChild;
 use Tests\Liip\Serializer\Fixtures\FloatProperty;
 use Tests\Liip\Serializer\Fixtures\Inheritance;
 use Tests\Liip\Serializer\Fixtures\ListModel;
@@ -67,17 +73,17 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::assertNull($model->unAnnotated);
         self::assertInstanceOf(Nested::class, $model->nestedField);
         self::assertSame('nested', $model->nestedField->nestedString);
-        self::assertInstanceOf(\DateTime::class, $model->date);
+        self::assertInstanceOf(DateTime::class, $model->date);
         self::assertSame('2018-08-03', $model->date->format('Y-m-d'));
-        self::assertInstanceOf(\DateTime::class, $model->dateWithFormat);
+        self::assertInstanceOf(DateTime::class, $model->dateWithFormat);
         self::assertSame('2018-08-04', $model->dateWithFormat->format('Y-m-d'));
-        self::assertInstanceOf(\DateTime::class, $model->dateWithOneDeserializationFormat);
+        self::assertInstanceOf(DateTime::class, $model->dateWithOneDeserializationFormat);
         self::assertSame('2019-05-15', $model->dateWithOneDeserializationFormat->format('Y-m-d'));
-        self::assertInstanceOf(\DateTime::class, $model->dateWithMultipleDeserializationFormats);
+        self::assertInstanceOf(DateTime::class, $model->dateWithMultipleDeserializationFormats);
         self::assertSame('2019-05-16', $model->dateWithMultipleDeserializationFormats->format('Y-m-d'));
-        self::assertInstanceOf(\DateTime::class, $model->dateWithTimezone);
-        self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d'));
-        self::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
+        self::assertInstanceOf(DateTime::class, $model->dateWithTimezone);
+        self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d'));
+        self::assertInstanceOf(DateTimeImmutable::class, $model->dateImmutable);
         self::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
         self::assertSame('2016-06-01', $model->getDateImmutablePrivate()?->format('Y-m-d'));
     }
@@ -267,6 +273,37 @@ class DeserializerGeneratorTest extends SerializerTestCase
         $model = $functionName($input);
         self::assertInstanceOf(VirtualProperties::class, $model);
         self::assertSame('apiString', $model->apiString);
+    }
+
+    public function testDiscriminator(): void
+    {
+        $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_DiscriminatorDependency';
+        self::generateDeserializer(self::$metadataBuilder, DiscriminatorDependency::class, $functionName);
+
+
+        $input = [
+            'discriminator' => [
+                'first_property' => 'first-value',
+                'type' => 'first',
+            ],
+        ];
+        $model = $functionName($input);
+
+        self::assertInstanceOf(DiscriminatorDependency::class, $model);
+        self::assertInstanceOf(DiscriminatorFirstChild::class, $model->discriminator);
+        self::assertSame('first-value', $model->discriminator->firstProperty);
+
+        $input = [
+            'discriminator' => [
+                'second_property' => 'second-value',
+                'type' => 'second',
+            ],
+        ];
+        $model = $functionName($input);
+
+        self::assertInstanceOf(DiscriminatorDependency::class, $model);
+        self::assertInstanceOf(DiscriminatorSecondChild::class, $model->discriminator);
+        self::assertSame('second-value', $model->discriminator->secondProperty);
     }
 
     public function testPostDeserialize(): void

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Liip\Serializer\Unit;
 
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Collections\ArrayCollection;
 use Liip\MetadataParser\Builder;
@@ -77,17 +74,17 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::assertNull($model->unAnnotated);
         self::assertInstanceOf(Nested::class, $model->nestedField);
         self::assertSame('nested', $model->nestedField->nestedString);
-        self::assertInstanceOf(DateTime::class, $model->date);
+        self::assertInstanceOf(\DateTime::class, $model->date);
         self::assertSame('2018-08-03', $model->date->format('Y-m-d'));
-        self::assertInstanceOf(DateTime::class, $model->dateWithFormat);
+        self::assertInstanceOf(\DateTime::class, $model->dateWithFormat);
         self::assertSame('2018-08-04', $model->dateWithFormat->format('Y-m-d'));
-        self::assertInstanceOf(DateTime::class, $model->dateWithOneDeserializationFormat);
+        self::assertInstanceOf(\DateTime::class, $model->dateWithOneDeserializationFormat);
         self::assertSame('2019-05-15', $model->dateWithOneDeserializationFormat->format('Y-m-d'));
-        self::assertInstanceOf(DateTime::class, $model->dateWithMultipleDeserializationFormats);
+        self::assertInstanceOf(\DateTime::class, $model->dateWithMultipleDeserializationFormats);
         self::assertSame('2019-05-16', $model->dateWithMultipleDeserializationFormats->format('Y-m-d'));
-        self::assertInstanceOf(DateTime::class, $model->dateWithTimezone);
-        self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d'));
-        self::assertInstanceOf(DateTimeImmutable::class, $model->dateImmutable);
+        self::assertInstanceOf(\DateTime::class, $model->dateWithTimezone);
+        self::assertSame('2018-08-03', $model->dateWithTimezone->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d'));
+        self::assertInstanceOf(\DateTimeImmutable::class, $model->dateImmutable);
         self::assertSame('2016-06-01', $model->dateImmutable->format('Y-m-d'));
         self::assertSame('2016-06-01', $model->getDateImmutablePrivate()?->format('Y-m-d'));
     }

--- a/tests/Unit/DeserializerGeneratorTest.php
+++ b/tests/Unit/DeserializerGeneratorTest.php
@@ -15,7 +15,10 @@ use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
 use Liip\Serializer\DeserializerGenerator;
 use Liip\Serializer\Template\Deserialization;
+use Tests\Liip\Serializer\Fixtures\ComplexUnionTyping;
 use Tests\Liip\Serializer\Fixtures\ContainsNonEmptyConstructor;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorAuthor;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorComment;
 use Tests\Liip\Serializer\Fixtures\DiscriminatorDependency;
 use Tests\Liip\Serializer\Fixtures\DiscriminatorFirstChild;
 use Tests\Liip\Serializer\Fixtures\DiscriminatorSecondChild;
@@ -26,6 +29,7 @@ use Tests\Liip\Serializer\Fixtures\Model;
 use Tests\Liip\Serializer\Fixtures\Nested;
 use Tests\Liip\Serializer\Fixtures\NonEmptyConstructor;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
+use Tests\Liip\Serializer\Fixtures\PrimitiveUnionTyping;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
 use Tests\Liip\Serializer\Fixtures\RecursionModel;
 use Tests\Liip\Serializer\Fixtures\UnknownArraySubType;
@@ -280,7 +284,6 @@ class DeserializerGeneratorTest extends SerializerTestCase
         $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_DiscriminatorDependency';
         self::generateDeserializer(self::$metadataBuilder, DiscriminatorDependency::class, $functionName);
 
-
         $input = [
             'discriminator' => [
                 'first_property' => 'first-value',
@@ -304,6 +307,66 @@ class DeserializerGeneratorTest extends SerializerTestCase
         self::assertInstanceOf(DiscriminatorDependency::class, $model);
         self::assertInstanceOf(DiscriminatorSecondChild::class, $model->discriminator);
         self::assertSame('second-value', $model->discriminator->secondProperty);
+    }
+
+    public function testComplexUnionDiscriminator(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            self::markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
+        }
+
+        $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_ComplexUnionTyping';
+        self::generateDeserializer(self::$metadataBuilder, ComplexUnionTyping::class, $functionName);
+
+        $input = [
+            'property' => [
+                'text' => 'my-text',
+                'objectType' => 'comment',
+            ],
+        ];
+        $model = $functionName($input);
+
+        self::assertInstanceOf(ComplexUnionTyping::class, $model);
+        self::assertInstanceOf(DiscriminatorComment::class, $model->property);
+        self::assertSame('my-text', $model->property->text);
+
+        $input = [
+            'property' => [
+                'name' => 'my-author',
+                'objectType' => 'author',
+            ],
+        ];
+        $model = $functionName($input);
+
+        self::assertInstanceOf(ComplexUnionTyping::class, $model);
+        self::assertInstanceOf(DiscriminatorAuthor::class, $model->property);
+        self::assertSame('my-author', $model->property->name);
+    }
+
+    /**
+     * @dataProvider providePrimitiveUnionDiscriminatorCases
+     */
+    public function testPrimitiveUnionDiscriminator(mixed $propertyValue): void
+    {
+        $functionName = 'deserialize_Tests_Liip_Serializer_Fixtures_PrimitiveUnionTyping';
+        self::generateDeserializer(self::$metadataBuilder, PrimitiveUnionTyping::class, $functionName, ['allow_generic_arrays' => true]);
+
+        $input = ['property' => $propertyValue];
+        $model = $functionName($input);
+
+        self::assertInstanceOf(PrimitiveUnionTyping::class, $model);
+        self::assertSame($propertyValue, $model->property);
+    }
+
+    public static function providePrimitiveUnionDiscriminatorCases(): iterable
+    {
+        return [
+            [42],
+            ['string-value'],
+            [false],
+            [0.5],
+            [['key' => 'value', 'another_key' => 'another_value']],
+        ];
     }
 
     public function testPostDeserialize(): void

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -17,7 +17,10 @@ use Liip\MetadataParser\ModelParser\ReflectionParser;
 use stdClass;
 use Tests\Liip\Serializer\Fixtures\AccessorOrder;
 use Tests\Liip\Serializer\Fixtures\AccessorOrderInherit;
+use Tests\Liip\Serializer\Fixtures\ComplexUnionTyping;
 use Tests\Liip\Serializer\Fixtures\ContainsPrivateProperty;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorAuthor;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorComment;
 use Tests\Liip\Serializer\Fixtures\DiscriminatorDependency;
 use Tests\Liip\Serializer\Fixtures\DiscriminatorFirstChild;
 use Tests\Liip\Serializer\Fixtures\InaccessiblePrivateProperty;
@@ -27,6 +30,7 @@ use Tests\Liip\Serializer\Fixtures\Model;
 use Tests\Liip\Serializer\Fixtures\MultidimensionalArrayForPrimitive;
 use Tests\Liip\Serializer\Fixtures\Nested;
 use Tests\Liip\Serializer\Fixtures\PostDeserialize;
+use Tests\Liip\Serializer\Fixtures\PrimitiveUnionTyping;
 use Tests\Liip\Serializer\Fixtures\PrivateProperty;
 use Tests\Liip\Serializer\Fixtures\RecursionModel;
 use Tests\Liip\Serializer\Fixtures\UnknownArraySubType;
@@ -368,6 +372,72 @@ class SerializerGeneratorTest extends SerializerTestCase
         $data = $functionName($model);
 
         self::assertSame($expected, $data);
+    }
+
+    public function testComplexUnionDiscriminator(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            self::markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
+        }
+
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_ComplexUnionTyping_2';
+        self::generateSerializers(self::$metadataBuilder, ComplexUnionTyping::class, [$functionName]);
+
+        $model = new ComplexUnionTyping();
+        $model->property = new DiscriminatorAuthor();
+        $model->property->name = 'author-name';
+
+        $expected = [
+            'property' => [
+                'name' => 'author-name',
+                'objectType' => 'author',
+            ],
+        ];
+        $data = $functionName($model);
+
+        self::assertSame($expected, $data);
+
+        $model = new ComplexUnionTyping();
+        $model->property = new DiscriminatorComment();
+        $model->property->text = 'comment-text';
+
+        $expected = [
+            'property' => [
+                'text' => 'comment-text',
+                'objectType' => 'comment',
+            ],
+        ];
+        $data = $functionName($model);
+
+        self::assertSame($expected, $data);
+    }
+
+    /**
+     * @dataProvider providePrimitiveUnionDiscriminatorCases
+     */
+    public function testPrimitiveUnionDiscriminator(mixed $propertyValue): void
+    {
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_PrimitiveUnionTyping';
+        self::generateSerializers(self::$metadataBuilder, PrimitiveUnionTyping::class, [$functionName], [''], [], ['allow_generic_arrays' => true]);
+
+        $model = new PrimitiveUnionTyping();
+        $model->property = $propertyValue;
+
+        $expected = ['property' => $propertyValue];
+        $data = $functionName($model);
+
+        self::assertSame($expected, $data);
+    }
+
+    public static function providePrimitiveUnionDiscriminatorCases(): iterable
+    {
+        return [
+            [42],
+            ['string-value'],
+            [false],
+            [0.5],
+            [['key' => 'value', 'another_key' => 'another_value']],
+        ];
     }
 
     /**

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Liip\Serializer\Unit;
 
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Collections\ArrayCollection;
-use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
-use stdClass;
 use Tests\Liip\Serializer\Fixtures\AccessorOrder;
 use Tests\Liip\Serializer\Fixtures\AccessorOrderInherit;
 use Tests\Liip\Serializer\Fixtures\ComplexUnionTyping;
@@ -70,8 +65,8 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model->detailString = 'details';
         $model->unAnnotated = 'unAnnotated';
         $model->nestedField = new Nested('nested');
-        $model->date = new DateTime('2018-08-03', new DateTimeZone('Europe/Zurich'));
-        $model->dateImmutable = new DateTimeImmutable('2016-06-01', new DateTimeZone('Europe/Zurich'));
+        $model->date = new \DateTime('2018-08-03', new \DateTimeZone('Europe/Zurich'));
+        $model->dateImmutable = new \DateTimeImmutable('2016-06-01', new \DateTimeZone('Europe/Zurich'));
 
         $expected = [
             'api_string' => 'api',
@@ -217,7 +212,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model = new Model();
         $data = $functionName($model);
 
-        self::assertInstanceOf(stdClass::class, $data);
+        self::assertInstanceOf(\stdClass::class, $data);
         self::assertCount(0, get_object_vars($data));
     }
 
@@ -238,7 +233,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         self::generateSerializers(self::$metadataBuilder, Model::class, [$functionName]);
 
         $model = new Model();
-        $model->dateWithFormat = new DateTime('2020-04-22 10:11:12');
+        $model->dateWithFormat = new \DateTime('2020-04-22 10:11:12');
         $data = $functionName($model);
 
         self::assertSame(['date_with_format' => '2020-04-22'], $data);
@@ -264,7 +259,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         self::assertArrayHasKey('list_nested', $data);
         self::assertSame([], $data['list_nested']);
         self::assertArrayHasKey('hashmap', $data);
-        self::assertInstanceOf(stdClass::class, $data['hashmap']);
+        self::assertInstanceOf(\stdClass::class, $data['hashmap']);
         self::assertCount(0, get_object_vars($data['hashmap']));
     }
 
@@ -551,7 +546,7 @@ class SerializerGeneratorTest extends SerializerTestCase
 
     public function testInaccessibleProperty(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('is not public and no getter has been defined');
 
         self::generateSerializers(self::$metadataBuilder, InaccessiblePrivateProperty::class, ['should never get here']);

--- a/tests/Unit/SerializerGeneratorTest.php
+++ b/tests/Unit/SerializerGeneratorTest.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Tests\Liip\Serializer\Unit;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Collections\ArrayCollection;
+use Exception;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
+use stdClass;
 use Tests\Liip\Serializer\Fixtures\AccessorOrder;
 use Tests\Liip\Serializer\Fixtures\AccessorOrderInherit;
 use Tests\Liip\Serializer\Fixtures\ContainsPrivateProperty;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorDependency;
+use Tests\Liip\Serializer\Fixtures\DiscriminatorFirstChild;
 use Tests\Liip\Serializer\Fixtures\InaccessiblePrivateProperty;
 use Tests\Liip\Serializer\Fixtures\Inheritance;
 use Tests\Liip\Serializer\Fixtures\ListModel;
@@ -59,8 +66,8 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model->detailString = 'details';
         $model->unAnnotated = 'unAnnotated';
         $model->nestedField = new Nested('nested');
-        $model->date = new \DateTime('2018-08-03', new \DateTimeZone('Europe/Zurich'));
-        $model->dateImmutable = new \DateTimeImmutable('2016-06-01', new \DateTimeZone('Europe/Zurich'));
+        $model->date = new DateTime('2018-08-03', new DateTimeZone('Europe/Zurich'));
+        $model->dateImmutable = new DateTimeImmutable('2016-06-01', new DateTimeZone('Europe/Zurich'));
 
         $expected = [
             'api_string' => 'api',
@@ -206,7 +213,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         $model = new Model();
         $data = $functionName($model);
 
-        self::assertInstanceOf(\stdClass::class, $data);
+        self::assertInstanceOf(stdClass::class, $data);
         self::assertCount(0, get_object_vars($data));
     }
 
@@ -227,7 +234,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         self::generateSerializers(self::$metadataBuilder, Model::class, [$functionName]);
 
         $model = new Model();
-        $model->dateWithFormat = new \DateTime('2020-04-22 10:11:12');
+        $model->dateWithFormat = new DateTime('2020-04-22 10:11:12');
         $data = $functionName($model);
 
         self::assertSame(['date_with_format' => '2020-04-22'], $data);
@@ -253,7 +260,7 @@ class SerializerGeneratorTest extends SerializerTestCase
         self::assertArrayHasKey('list_nested', $data);
         self::assertSame([], $data['list_nested']);
         self::assertArrayHasKey('hashmap', $data);
-        self::assertInstanceOf(\stdClass::class, $data['hashmap']);
+        self::assertInstanceOf(stdClass::class, $data['hashmap']);
         self::assertCount(0, get_object_vars($data['hashmap']));
     }
 
@@ -337,6 +344,26 @@ class SerializerGeneratorTest extends SerializerTestCase
         $expected = [
             'api_string' => 'apiString',
             'api_string_virtual' => 'apiString_virtual',
+        ];
+        $data = $functionName($model);
+
+        self::assertSame($expected, $data);
+    }
+
+    public function testDiscriminator(): void
+    {
+        $functionName = 'serialize_Tests_Liip_Serializer_Fixtures_DiscriminatorDependency_2';
+        self::generateSerializers(self::$metadataBuilder, DiscriminatorDependency::class, [$functionName]);
+
+        $model = new DiscriminatorDependency();
+        $model->discriminator = new DiscriminatorFirstChild();
+        $model->discriminator->firstProperty = 'my-value';
+
+        $expected = [
+            'discriminator' => [
+                'first_property' => 'my-value',
+                'type' => 'first',
+            ],
         ];
         $data = $functionName($model);
 
@@ -454,7 +481,7 @@ class SerializerGeneratorTest extends SerializerTestCase
 
     public function testInaccessibleProperty(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('is not public and no getter has been defined');
 
         self::generateSerializers(self::$metadataBuilder, InaccessiblePrivateProperty::class, ['should never get here']);


### PR DESCRIPTION
With these changes it is now possible to use (union) discriminators. A few examples which are supported might look like this 👇 

<details>
<summary>Examples</summary>


### Discriminators

```php
#[JMS\Discriminator(field: 'type', map: ['first' => FirstClass::class, 'second' => SecondClass::class])]
abstract class Discriminator
{
}

class FirstClass extends Discriminator
{
    public string $firstProperty;
}

class SecondClass extends Discriminator
{
    public int $secondProperty;
}
```

### Union Discriminators

```php
use JMS\Serializer\Annotation\UnionDiscriminator;

class JmsUnionTyping
{
    #[UnionDiscriminator(field: 'objectType', map: ['comment' => FirstClass::class, 'author' => SecondClass::class])]
    public FirstClass|SecondClass $property;
}

// ...

class PrimitiveUnionTyping
{
    public int|string|false|float|array|null $property;
}
```


</details>

To support this, it is necessary to use the latest changes from the `2.x` branch from the `metadata-parser` (including the changes necessary for union discriminators via https://github.com/liip/metadata-parser/pull/54).
So ideally this change should go into a new `3.x` branch where we then release a new major version, as doing a minor release will potentially break peoples implementation since a few things changed in the parse library.

Side note: There is a temporary commit in here which uses the changes from the other PR in the `metadata-parser` repo. It will be removed/adjusted, once merged and a new version exists.
