### PR TITLE
improvement(serializer,2.x): cache requested (de-)serializations

### DIFF
--- a/src/Recursion.php
+++ b/src/Recursion.php
@@ -48,7 +48,7 @@ abstract class Recursion
             $type = $type->getLeafType();
         }
 
-        if (!($type instanceof PropertyTypeClass)) {
+        if (!$type instanceof PropertyTypeClass) {
             return null;
         }
 

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -111,7 +111,7 @@ final class Serializer implements SerializerInterface
             $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
-            if (!\file_exists($filename)) {
+            if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
             }
 
@@ -159,7 +159,7 @@ final class Serializer implements SerializerInterface
 
         if (!isset($this->cachedSerializers[$functionName])) {
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-            if (!\file_exists($filename)) {
+            if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
             }
 

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -93,7 +93,6 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        /** @var (callable(array<mixed>): object)&string $functionName */
         $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
 
         if (!\function_exists($functionName)) {
@@ -104,6 +103,7 @@ final class Serializer implements SerializerInterface
 
             require_once $filename;
 
+            /* @phpstan-ignore booleanNot.alwaysTrue */
             if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
@@ -125,30 +125,26 @@ final class Serializer implements SerializerInterface
             throw new UnsupportedTypeException('The Liip Serializer only works for objects');
         }
         $type = $data::class;
-
+        $groups = [];
+        $version = null;
         if ($context) {
-            $groups = [];
-            $version = null;
             $groups = $context->getGroups();
             if ($context->getVersion()) {
                 $version = $context->getVersion();
             }
-            $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
-        } else {
-            $functionName = SerializerGenerator::buildSerializerFunctionName($type, null, []);
         }
+
+        $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
 
         if (!\function_exists($functionName)) {
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
             if (!file_exists($filename)) {
-                throw $context
-                    ? UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups)
-                    : UnsupportedTypeException::typeUnsupportedSerialization($type, null, [])
-                ;
+                throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
             }
 
             require_once $filename;
 
+            /* @phpstan-ignore booleanNot.alwaysTrue */
             if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -102,7 +102,7 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        // todo: index cache by function name when deserializing with groups/versions is supported
+        // todo: index cache by function name instead of type when deserializing with groups/versions is supported
         if (isset($this->cachedDeserializers[$type])) {
             $functionName = $this->cachedDeserializers[$type];
         } else {
@@ -147,7 +147,7 @@ final class Serializer implements SerializerInterface
         }
 
         if (!($version || $groups)) {
-            $functionName = $this->cachedDeserializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+            $functionName = $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
         } else {
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
@@ -163,6 +163,8 @@ final class Serializer implements SerializerInterface
             if (!\is_callable($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
+
+            $this->cachedSerializers[$functionName] = $functionName;
         }
 
         try {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -18,6 +18,15 @@ use Pnz\JsonException\Json;
  */
 final class Serializer implements SerializerInterface
 {
+    /**
+     * @var array<string, callable(object): array>
+     */
+    private array $cachedSerializers = [];
+    /**
+     * @var array<string, callable(array): object>
+     */
+    private array $cachedDeserializers = [];
+
     public function __construct(private string $cacheDirectory)
     {
     }
@@ -93,15 +102,23 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
-        $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-        if (!file_exists($filename)) {
-            throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
-        }
-        require_once $filename;
+        // todo: index cache by function name when deserializing with groups/versions is supported
+        if (isset($this->cachedDeserializers[$type])) {
+            $functionName = $this->cachedDeserializers[$type];
+        } else {
+            $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
-        if (!\is_callable($functionName)) {
-            throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            if (!\file_exists($filename)) {
+                throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
+            }
+
+            require_once $filename;
+
+            if (!\is_callable($functionName)) {
+                throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            }
+            $this->cachedDeserializers[$type] = $functionName;
         }
 
         try {
@@ -128,16 +145,24 @@ final class Serializer implements SerializerInterface
                 $version = $context->getVersion();
             }
         }
-        $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version ?: null, $groups);
-        $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-        if (!file_exists($filename)) {
-            throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+
+        if (!($version || $groups)) {
+            $functionName = $this->cachedDeserializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+        } else {
+            $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
 
-        require_once $filename;
+        if (!isset($this->cachedSerializers[$functionName])) {
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
+            if (!\file_exists($filename)) {
+                throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+            }
 
-        if (!\is_callable($functionName)) {
-            throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            require_once $filename;
+
+            if (!\is_callable($functionName)) {
+                throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            }
         }
 
         try {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -18,15 +18,6 @@ use Pnz\JsonException\Json;
  */
 final class Serializer implements SerializerInterface
 {
-    /**
-     * @var array<string, (callable(object, bool=): array<mixed>)|string>
-     */
-    private array $cachedSerializers = [];
-    /**
-     * @var array<string, (callable(array<mixed>): object)|string>
-     */
-    private array $cachedDeserializers = [];
-
     public function __construct(private string $cacheDirectory)
     {
     }
@@ -102,25 +93,20 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        // todo: index cache by function name instead of type when deserializing with groups/versions is supported
-        if (isset($this->cachedDeserializers[$type])) {
-            /** @var callable(array<mixed>): object $functionName */
-            $functionName = $this->cachedDeserializers[$type];
-        } else {
-            /** @var (callable(array<mixed>): object)&string $functionName */
-            $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
-            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
+        /** @var (callable(array<mixed>): object)&string $functionName */
+        $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
 
+        if (!\function_exists($functionName)) {
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
             if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
             }
 
             require_once $filename;
 
-            if (!\is_callable($functionName)) {
+            if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
-            $this->cachedDeserializers[$type] = $functionName;
         }
 
         try {
@@ -139,37 +125,33 @@ final class Serializer implements SerializerInterface
             throw new UnsupportedTypeException('The Liip Serializer only works for objects');
         }
         $type = $data::class;
-        $groups = [];
-        $version = null;
+
         if ($context) {
+            $groups = [];
+            $version = null;
             $groups = $context->getGroups();
             if ($context->getVersion()) {
                 $version = $context->getVersion();
             }
-        }
-
-        if (!($version || $groups)) {
-            $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
-            /** @var (callable(object): array<mixed>)&string $functionName */
-            $functionName = $this->cachedSerializers[$type];
-        } else {
-            /** @var (callable(object): array<mixed>)&string $functionName */
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
+        } else {
+            $functionName = SerializerGenerator::buildSerializerFunctionName($type, null, []);
         }
 
-        if (!isset($this->cachedSerializers[$functionName])) {
+        if (!\function_exists($functionName)) {
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
             if (!file_exists($filename)) {
-                throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+                throw $context
+                    ? UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups)
+                    : UnsupportedTypeException::typeUnsupportedSerialization($type, null, [])
+                ;
             }
 
             require_once $filename;
 
-            if (!\is_callable($functionName)) {
+            if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
-
-            $this->cachedSerializers[$functionName] = $functionName;
         }
 
         try {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -19,11 +19,11 @@ use Pnz\JsonException\Json;
 final class Serializer implements SerializerInterface
 {
     /**
-     * @var array<string, callable(object): array>
+     * @var array<string, (callable(object, bool=): array<mixed>)|string>
      */
     private array $cachedSerializers = [];
     /**
-     * @var array<string, callable(array): object>
+     * @var array<string, (callable(array<mixed>): object)|string>
      */
     private array $cachedDeserializers = [];
 
@@ -104,8 +104,10 @@ final class Serializer implements SerializerInterface
 
         // todo: index cache by function name instead of type when deserializing with groups/versions is supported
         if (isset($this->cachedDeserializers[$type])) {
+            /** @var callable(array<mixed>): object $functionName */
             $functionName = $this->cachedDeserializers[$type];
         } else {
+            /** @var (callable(array<mixed>): object)&string $functionName */
             $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
@@ -147,8 +149,11 @@ final class Serializer implements SerializerInterface
         }
 
         if (!($version || $groups)) {
-            $functionName = $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+            $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+            /** @var (callable(object): array<mixed>)&string $functionName */
+            $functionName = $this->cachedSerializers[$type];
         } else {
+            /** @var (callable(object): array<mixed>)&string $functionName */
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
 

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -15,6 +15,8 @@ use Tests\Liip\Serializer\Fixtures\SerializerModel;
 
 /**
  * @small
+ *
+ * @runTestsInSeparateProcesses
  */
 class SerializerTest extends TestCase
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Improvement to Serializer's `objectToArray` and `arrayToObject`: cache all loaded (de-)serializers. This PR targets the 2.x, I will make a similar one for 3.x


#### Why?

The Serializer's `objectToArray` and `arrayToObject` have a lot of unnecessary initialization being executed on each call:
- build a function name
- check that the file does exist
- `require_once` that file (php skips the file if it was loaded previously)
- check again that the function was indeed correctly loaded

All of this is supposed to be a one-off, final operation to load and define the (de-)serializer functions. This PR caches every serializer/deserializer to limit initialization work.

The difference should show up more and more when processing large amounts of data, but I haven't even made a benchmark for my current projects, let alone a standalone one to show the difference


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

#### To Do

- [ ] Would it be acceptable to create a way of (de-)serializing a list, to have the (de-)serializer selection be done only once for a set of object known to b of the same type ? The two ways of doing this would be either one of:
  - [ ]  BC break in SerializerInterface by adding a new `manyToArray`, and the reciprocate `manyFromArray`,
  - [ ] Making `serialize`/`deserialize` capable of parsing types like `array<FullyQualifiedClassName>` 
- [ ] Could we make `simdjson` replace the basic `json_decode` if available? From testing myself, I think the performance difference is worth bringing `pnz/json-exception` into this package
