### PR TITLE
improvement(serializer,3.x): cache requested (de-)serializations

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -18,15 +18,6 @@ use Pnz\JsonException\Json;
  */
 final class Serializer implements SerializerInterface
 {
-    /**
-     * @var array<string, (callable(object, bool=): array<mixed>)|string>
-     */
-    private array $cachedSerializers = [];
-    /**
-     * @var array<string, (callable(array<mixed>): object)|string>
-     */
-    private array $cachedDeserializers = [];
-
     public function __construct(private string $cacheDirectory)
     {
     }
@@ -102,25 +93,20 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        // todo: index cache by function name instead of type when deserializing with groups/versions is supported
-        if (isset($this->cachedDeserializers[$type])) {
-            /** @var callable(array<mixed>): object $functionName */
-            $functionName = $this->cachedDeserializers[$type];
-        } else {
-            $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
-            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
+        $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
 
+        if (!\function_exists($functionName)) {
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
             if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
             }
 
             require_once $filename;
 
-            if (!\is_callable($functionName)) {
+            /* @phpstan-ignore booleanNot.alwaysTrue */
+            if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
-            /** @var (callable(array<mixed>): object)&string $functionName */
-            $this->cachedDeserializers[$type] = $functionName;
         }
 
         try {
@@ -139,41 +125,37 @@ final class Serializer implements SerializerInterface
             throw new UnsupportedTypeException('The Liip Serializer only works for objects');
         }
         $type = $data::class;
-        $groups = [];
-        $version = null;
+
         if ($context) {
+            $groups = [];
+            $version = null;
             $groups = $context->getGroups();
             if ($context->getVersion()) {
                 $version = $context->getVersion();
             }
-        }
-
-        if (!($version || $groups)) {
-            $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
-            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
-            $functionName = $this->cachedSerializers[$type];
-        } else {
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
+        } else {
+            $functionName = SerializerGenerator::buildSerializerFunctionName($type, null, []);
         }
 
-        if (!isset($this->cachedSerializers[$functionName])) {
+        if (!\function_exists($functionName)) {
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
             if (!file_exists($filename)) {
-                throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+                throw $context
+                    ? UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups)
+                    : UnsupportedTypeException::typeUnsupportedSerialization($type, null, [])
+                ;
             }
 
             require_once $filename;
 
-            if (!\is_callable($functionName)) {
+            /* @phpstan-ignore booleanNot.alwaysTrue */
+            if (!\function_exists($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
-
-            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
-            $this->cachedSerializers[$functionName] = $functionName;
         }
 
         try {
-            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
             return $functionName($data, $useStdClass);
         } catch (\Throwable $t) {
             throw new Exception('Error during serialization', 0, $t);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -18,6 +18,15 @@ use Pnz\JsonException\Json;
  */
 final class Serializer implements SerializerInterface
 {
+    /**
+     * @var array<string, callable(object): array>
+     */
+    private array $cachedSerializers = [];
+    /**
+     * @var array<string, callable(array): object>
+     */
+    private array $cachedDeserializers = [];
+
     public function __construct(private string $cacheDirectory)
     {
     }
@@ -93,15 +102,23 @@ final class Serializer implements SerializerInterface
             throw new Exception('Version and group support is not implemented for deserialization. It is only supported for serialization');
         }
 
-        $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
-        $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-        if (!file_exists($filename)) {
-            throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
-        }
-        require_once $filename;
+        // todo: index cache by function name instead of type when deserializing with groups/versions is supported
+        if (isset($this->cachedDeserializers[$type])) {
+            $functionName = $this->cachedDeserializers[$type];
+        } else {
+            $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
-        if (!\is_callable($functionName)) {
-            throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            if (!\file_exists($filename)) {
+                throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
+            }
+
+            require_once $filename;
+
+            if (!\is_callable($functionName)) {
+                throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            }
+            $this->cachedDeserializers[$type] = $functionName;
         }
 
         try {
@@ -128,16 +145,26 @@ final class Serializer implements SerializerInterface
                 $version = $context->getVersion();
             }
         }
-        $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version ?: null, $groups);
-        $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-        if (!file_exists($filename)) {
-            throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+
+        if (!($version || $groups)) {
+            $functionName = $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+        } else {
+            $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
 
-        require_once $filename;
+        if (!isset($this->cachedSerializers[$functionName])) {
+            $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
+            if (!\file_exists($filename)) {
+                throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
+            }
 
-        if (!\is_callable($functionName)) {
-            throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            require_once $filename;
+
+            if (!\is_callable($functionName)) {
+                throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
+            }
+
+            $this->cachedSerializers[$functionName] = $functionName;
         }
 
         try {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -107,11 +107,10 @@ final class Serializer implements SerializerInterface
             /** @var callable(array<mixed>): object $functionName */
             $functionName = $this->cachedDeserializers[$type];
         } else {
-            /** @var (callable(array<mixed>): object)&string $functionName */
             $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
-            if (!\file_exists($filename)) {
+            if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedDeserialization($type);
             }
 
@@ -120,6 +119,7 @@ final class Serializer implements SerializerInterface
             if (!\is_callable($functionName)) {
                 throw new Exception(\sprintf('Internal Error: Deserializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
+            /** @var (callable(array<mixed>): object)&string $functionName */
             $this->cachedDeserializers[$type] = $functionName;
         }
 
@@ -150,16 +150,15 @@ final class Serializer implements SerializerInterface
 
         if (!($version || $groups)) {
             $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
-            /** @var (callable(object): array<mixed>)&string $functionName */
+            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
             $functionName = $this->cachedSerializers[$type];
         } else {
-            /** @var (callable(object): array<mixed>)&string $functionName */
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
 
         if (!isset($this->cachedSerializers[$functionName])) {
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
-            if (!\file_exists($filename)) {
+            if (!file_exists($filename)) {
                 throw UnsupportedTypeException::typeUnsupportedSerialization($type, $version, $groups);
             }
 
@@ -169,10 +168,12 @@ final class Serializer implements SerializerInterface
                 throw new Exception(\sprintf('Internal Error: Serializer for %s in file %s does not have expected function %s', $type, $filename, $functionName));
             }
 
+            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
             $this->cachedSerializers[$functionName] = $functionName;
         }
 
         try {
+            /** @var (callable(object, bool=): array<mixed>)&string $functionName */
             return $functionName($data, $useStdClass);
         } catch (\Throwable $t) {
             throw new Exception('Error during serialization', 0, $t);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -19,11 +19,11 @@ use Pnz\JsonException\Json;
 final class Serializer implements SerializerInterface
 {
     /**
-     * @var array<string, callable(object): array>
+     * @var array<string, (callable(object, bool=): array<mixed>)|string>
      */
     private array $cachedSerializers = [];
     /**
-     * @var array<string, callable(array): object>
+     * @var array<string, (callable(array<mixed>): object)|string>
      */
     private array $cachedDeserializers = [];
 
@@ -104,8 +104,10 @@ final class Serializer implements SerializerInterface
 
         // todo: index cache by function name instead of type when deserializing with groups/versions is supported
         if (isset($this->cachedDeserializers[$type])) {
+            /** @var callable(array<mixed>): object $functionName */
             $functionName = $this->cachedDeserializers[$type];
         } else {
+            /** @var (callable(array<mixed>): object)&string $functionName */
             $functionName = DeserializerGenerator::buildDeserializerFunctionName($type);
             $filename = \sprintf('%s/%s.php', $this->cacheDirectory, $functionName);
 
@@ -147,8 +149,11 @@ final class Serializer implements SerializerInterface
         }
 
         if (!($version || $groups)) {
-            $functionName = $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+            $this->cachedSerializers[$type] ??= SerializerGenerator::buildSerializerFunctionName($type, null, []);
+            /** @var (callable(object): array<mixed>)&string $functionName */
+            $functionName = $this->cachedSerializers[$type];
         } else {
+            /** @var (callable(object): array<mixed>)&string $functionName */
             $functionName = SerializerGenerator::buildSerializerFunctionName($type, $version, $groups);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Same as #52, for 3.x
| Documentation   | 
| License         | MIT


#### What's in this PR?

Improvement to Serializer's objectToArray and arrayToObject: cache all loaded (de-)serializers. This PR targets the 3.x, like #52 targets the 2.x


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

